### PR TITLE
Expand nodemon watch scope (#26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/server.js",
   "scripts": {
-    "dev": "nodemon --inspect --watch \"src/**/*.ts\" --exec \"node -r @swc-node/register\" src/server.ts",
+    "dev": "nodemon --inspect --watch \".\" --watch \".swcrc\" --ext \"ts,js,mjs,json,md,sh,zsh,env\" --exec \"node -r @swc-node/register\" src/server.ts",
     "start": "node dist/server.js",
     "build": "swc src -d dist",
     "test": "jest",


### PR DESCRIPTION
### Problem:
  The previous `--watch "src/**/*.ts"` configuration only monitored `.ts` files in the `src` directory, excluding root-level files and non-standard extensions like `.swcrc`.

### Solution:
  - Update the `--watch` flag to `"."` for watching all files.  
  - Guarantee support for specified file types via `--ext` (`ts,js,mjs,json,md,sh,zsh,env`).  
  - Explicitly add `.swcrc` using an additional `--watch` flag.  

### Usage Notes:
  - File extensions can be added to `--ext` as needed.  
  - Define unrecognized file types explicitly with another `--watch` flag.  

This update ensures a more comprehensive and flexible hot-reloading setup for development.

Closes #26 