### PR TITLE
Optimize SuperTest implementation to use a separate port from dev server (#2)

### DIFF
--- a/src/__tests__/serverIntegration.test.ts
+++ b/src/__tests__/serverIntegration.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import { app, createServer } from "@/server";
 import { findAvailablePort } from "@/utils/ports";
-import { Server } from "http";
+import { IncomingMessage, Server, ServerResponse } from "http";
 
 /**
  * NOTE: Testing suite currently requires the dev server on port 3000 to be stopped.
@@ -13,7 +13,7 @@ interface GraphQLResponse {
   errors?: Array<{ message: string }>;
 }
 
-let testServer: Server;
+let testServer: Server<typeof IncomingMessage, typeof ServerResponse>;
 
 beforeAll(async () => {
   const port: number = await findAvailablePort(4000);

--- a/src/__tests__/serverIntegration.test.ts
+++ b/src/__tests__/serverIntegration.test.ts
@@ -1,5 +1,7 @@
 import request from "supertest";
-import { app, server } from "@/server";
+import { app, createServer } from "@/server";
+import { findAvailablePort } from "@/utils/ports";
+import { Server } from "http";
 
 /**
  * NOTE: Testing suite currently requires the dev server on port 3000 to be stopped.
@@ -10,6 +12,13 @@ interface GraphQLResponse {
   data?: Record<string, unknown>;
   errors?: Array<{ message: string }>;
 }
+
+let testServer: Server;
+
+beforeAll(async () => {
+  const port: number = await findAvailablePort(4000);
+  testServer = await createServer(port.toString());
+});
 
 describe("GraphQL Server", () => {
   test("should return the correct menu data from the GraphQL query", async () => {
@@ -68,7 +77,7 @@ describe("GraphQL Server", () => {
   });
 });
 
-// Close the server after tests are complete
-afterAll(() => {
-  server.close();
+// Close the test server after tests are complete
+afterAll((done) => {
+  testServer.close(done);
 });

--- a/src/__tests__/serverIntegration.test.ts
+++ b/src/__tests__/serverIntegration.test.ts
@@ -4,8 +4,9 @@ import { findAvailablePort } from "@/utils/ports";
 import { IncomingMessage, Server, ServerResponse } from "http";
 
 /**
- * NOTE: Testing suite currently requires the dev server on port 3000 to be stopped.
- * TODO: Implement a way to run the tests on a different port.
+ * This file contains integration tests for the GraphQL server using SuperTest.
+ * The test suite runs on a dynamically selected port to avoid conflicts with
+ * the development server, allowing both to run simultaneously.
  */
 
 interface GraphQLResponse {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import morgan from "morgan";
 import helmet from "helmet";
 import { createYoga, createSchema, YogaServerInstance } from "graphql-yoga";
 import { typeDefs, resolvers } from "@/graphql";
-import { Server } from "http";
+import { IncomingMessage, Server, ServerResponse } from "http";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -214,13 +214,15 @@ const yoga: YogaServerInstance<object, object> = createYoga({
 });
 
 app.use("/graphql", graphqlRateLimiter, validateToken, yoga);
+
 const createServer = (customPort?: string): Promise<Server> => {
-  const port = customPort ?? process.env.PORT ?? "3000";
+  const port: string = customPort ?? process.env.PORT ?? "3000";
   return new Promise((resolve, reject) => {
-    const server = app.listen(port, () => {
-      console.log(`Server is running on http://localhost:${port}/graphql`);
-      resolve(server);
-    });
+    const server: Server<typeof IncomingMessage, typeof ServerResponse> =
+      app.listen(port, () => {
+        console.log(`Server is running on http://localhost:${port}/graphql`);
+        resolve(server);
+      });
 
     server.on("error", (err) => {
       reject(err);

--- a/src/server.ts
+++ b/src/server.ts
@@ -214,10 +214,25 @@ const yoga: YogaServerInstance<object, object> = createYoga({
 });
 
 app.use("/graphql", graphqlRateLimiter, validateToken, yoga);
+const createServer = (customPort?: string): Promise<Server> => {
+  const port = customPort ?? process.env.PORT ?? "3000";
+  return new Promise((resolve, reject) => {
+    const server = app.listen(port, () => {
+      console.log(`Server is running on http://localhost:${port}/graphql`);
+      resolve(server);
+    });
 
-const port: string = process.env.PORT ?? "3000";
-const server: Server = app.listen(port, () => {
-  console.log(`Server is running on http://localhost:${port}/graphql`);
-});
+    server.on("error", (err) => {
+      reject(err);
+    });
+  });
+};
 
-export { app, server };
+let server: Server | null = null;
+if (process.env.NODE_ENV !== "test") {
+  void createServer().then((s) => {
+    server = s;
+  });
+}
+
+export { app, server, createServer };

--- a/src/utils/ports.ts
+++ b/src/utils/ports.ts
@@ -1,0 +1,25 @@
+import net from "net";
+
+export const findAvailablePort = async (
+  startPort: number = 4000
+): Promise<number> => {
+  const isPortAvailable = (port: number): Promise<boolean> => {
+    return new Promise((resolve) => {
+      const server = net.createServer();
+      server.once("error", () => {
+        resolve(false);
+      });
+      server.once("listening", () => {
+        server.close();
+        resolve(true);
+      });
+      server.listen(port);
+    });
+  };
+
+  let port = startPort;
+  while (!(await isPortAvailable(port))) {
+    port++;
+  }
+  return port;
+};

--- a/src/utils/ports.ts
+++ b/src/utils/ports.ts
@@ -1,11 +1,11 @@
 import net from "net";
 
-export const findAvailablePort = async (
-  startPort: number = 4000
-): Promise<number> => {
+export const findAvailablePort: (
+  startPort?: number
+) => Promise<number> = async (startPort: number = 4000): Promise<number> => {
   const isPortAvailable = (port: number): Promise<boolean> => {
     return new Promise((resolve) => {
-      const server = net.createServer();
+      const server: net.Server = net.createServer();
       server.once("error", () => {
         resolve(false);
       });
@@ -17,7 +17,7 @@ export const findAvailablePort = async (
     });
   };
 
-  let port = startPort;
+  let port: number = startPort;
   while (!(await isPortAvailable(port))) {
     port++;
   }


### PR DESCRIPTION
### Summary  
The [SuperTest](https://github.com/ladjs/supertest) implementation now operates on a separate port, allowing the test suite to run concurrently with the development server.

### Key Changes  
- Updates the `createServer` function to support asynchronous server invocations.  
- Enhances test server lifecycle management by adding the `beforeAll` hook.  
- Introduces a `findAvailablePort` utility to identify an unused port, starting from `4000`.  
- Initializes the SuperTest instance on the identified port.  

### Reason for Change  
Previously, running the test suite parallel with the development server was impossible. Moreover, the `pre-commit` hook introduced in #23 blocked staged changes from being committed if the development server was active.  

With these updates, developers can keep the dev server running when invoking the `pnpm test` script.

Closes #2  