### PR TITLE
Implement update-licenses workflow with GitHub Actions (#94)

### DIFF
--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -1,0 +1,75 @@
+name: Update Licenses on Dependency Changes
+
+on:
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  update-licenses:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || 'master' }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: pnpm
+
+      - name: Install direct dependencies (without shamefully-hoist)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Add license-checker globally
+        run: pnpm add -g license-checker
+
+      - name: Generate licenses for direct dependencies
+        run: license-checker --json > licenses_main-deps.json
+
+      - name: Reinstall all dependencies with transitive dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts --shamefully-hoist
+
+      - name: Generate licenses for all dependencies
+        run: license-checker --json > licenses_sub-deps.json
+
+      - name: Display license files content
+        run: |
+          echo "==== Direct Dependencies (licenses_main-deps.json) ===="
+          cat licenses_main-deps.json
+          echo "==== Transitive Dependencies (licenses_sub-deps.json) ===="
+          cat licenses_sub-deps.json
+
+      - name: Commit and push updated license files
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add licenses_main-deps.json licenses_sub-deps.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: Update license files"
+            git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "No changes to commit."
+          fi

--- a/licenses_main-deps.json
+++ b/licenses_main-deps.json
@@ -1,0 +1,318 @@
+{
+  "@eslint-community/eslint-utils@4.4.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint-community/eslint-utils",
+    "publisher": "Toru Nagashima",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/eslint-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/eslint-utils/LICENSE"
+  },
+  "@eslint-community/regexpp@4.12.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint-community/regexpp",
+    "publisher": "Toru Nagashima",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/regexpp",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/regexpp/LICENSE"
+  },
+  "@eslint/config-array@0.19.2": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/config-array",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/config-array/LICENSE"
+  },
+  "@eslint/core@0.10.0": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/core/LICENSE"
+  },
+  "@eslint/eslintrc@3.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint/eslintrc",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/eslintrc",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/eslintrc/LICENSE"
+  },
+  "@eslint/js@9.19.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint/eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/js",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/js/LICENSE"
+  },
+  "@eslint/object-schema@2.1.6": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/object-schema",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/object-schema/LICENSE"
+  },
+  "@eslint/plugin-kit@0.2.5": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/plugin-kit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/plugin-kit/LICENSE"
+  },
+  "@graphql-tools/utils@10.7.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/graphql-tools",
+    "publisher": "Dotan Simha",
+    "email": "dotansimha@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/utils"
+  },
+  "@jest/types@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/types/LICENSE"
+  },
+  "@swc-node/register@1.10.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/swc-project/swc-node",
+    "publisher": "LongYinan",
+    "email": "github@lyn.one",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/register",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/register/LICENSE"
+  },
+  "@swc/cli@0.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/swc-project/pkgs",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/cli",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/cli/LICENSE"
+  },
+  "@swc/core@1.10.14": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/swc-project/swc",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/core"
+  },
+  "@types/cors@2.8.17": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/cors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/cors/LICENSE"
+  },
+  "@types/express@5.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/express",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/express/LICENSE"
+  },
+  "@types/jest@29.5.14": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/jest/LICENSE"
+  },
+  "@types/morgan@1.9.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/morgan",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/morgan/LICENSE"
+  },
+  "@types/supertest@6.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/supertest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/supertest/LICENSE"
+  },
+  "@typescript-eslint/eslint-plugin@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/eslint-plugin",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/eslint-plugin/LICENSE"
+  },
+  "@typescript-eslint/parser@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/parser/LICENSE"
+  },
+  "@typescript-eslint/scope-manager@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/scope-manager",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/scope-manager/LICENSE"
+  },
+  "@typescript-eslint/type-utils@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/type-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/type-utils/LICENSE"
+  },
+  "@typescript-eslint/types@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/types/LICENSE"
+  },
+  "@typescript-eslint/typescript-estree@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/typescript-estree",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/typescript-estree/LICENSE"
+  },
+  "@typescript-eslint/utils@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/utils/LICENSE"
+  },
+  "@typescript-eslint/visitor-keys@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/visitor-keys",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/visitor-keys/LICENSE"
+  },
+  "dotenv@16.4.7": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/motdotla/dotenv",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dotenv",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dotenv/LICENSE"
+  },
+  "eslint-scope@8.2.0": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/eslint/js",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-scope",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-scope/LICENSE"
+  },
+  "eslint-visitor-keys@4.2.0": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/js",
+    "publisher": "Toru Nagashima",
+    "url": "https://github.com/mysticatea",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-visitor-keys",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-visitor-keys/LICENSE"
+  },
+  "eslint@9.19.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint/eslint",
+    "publisher": "Nicholas C. Zakas",
+    "email": "nicholas+npm@nczconsulting.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint/LICENSE"
+  },
+  "express-rate-limit@7.5.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/express-rate-limit/express-rate-limit",
+    "publisher": "Nathan Friedly",
+    "url": "http://nfriedly.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express-rate-limit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express-rate-limit/license.md"
+  },
+  "express@4.21.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/expressjs/express",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express/LICENSE"
+  },
+  "globals@15.14.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/globals",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/globals",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/globals/license"
+  },
+  "graphql-tag@2.12.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/apollographql/graphql-tag",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-tag",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-tag/LICENSE"
+  },
+  "graphql-yoga@5.11.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dotansimha/graphql-yoga",
+    "publisher": "Saihajpreet Singh",
+    "email": "saihajpreet.singh@gmail.com",
+    "url": "https://saihaj.dev/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-yoga",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-yoga/LICENSE"
+  },
+  "graphql@16.10.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/graphql/graphql-js",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql/LICENSE"
+  },
+  "helmet@8.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/helmetjs/helmet",
+    "publisher": "Adam Baldwin",
+    "email": "adam@npmjs.com",
+    "url": "https://evilpacket.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/helmet",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/helmet/LICENSE"
+  },
+  "jest@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest/LICENSE"
+  },
+  "license-checker@25.0.1": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/davglass/license-checker",
+    "publisher": "Dav Glass",
+    "email": "davglass@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/license-checker",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/license-checker/LICENSE"
+  },
+  "morgan@1.10.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/expressjs/morgan",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/morgan",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/morgan/LICENSE"
+  },
+  "node-graphql-code-test@1.0.0": {
+    "licenses": "Custom: https://github.com/swc-project/swc-node",
+    "publisher": "mattfsourcecode",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/README.md"
+  },
+  "nodemon@3.1.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/remy/nodemon",
+    "publisher": "Remy Sharp",
+    "url": "https://github.com/remy",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/nodemon",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/nodemon/LICENSE"
+  },
+  "supertest@7.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ladjs/supertest",
+    "publisher": "TJ Holowaychuk",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supertest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supertest/LICENSE"
+  },
+  "ts-jest@29.2.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kulshekhar/ts-jest",
+    "publisher": "Kulshekhar Kabra",
+    "email": "kulshekhar@users.noreply.github.com",
+    "url": "https://github.com/kulshekhar",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-jest/LICENSE.md"
+  },
+  "typescript-eslint@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript-eslint",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript-eslint/LICENSE"
+  },
+  "typescript@5.7.3": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/microsoft/TypeScript",
+    "publisher": "Microsoft Corp.",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript/LICENSE.txt"
+  }
+}
+

--- a/licenses_sub-deps.json
+++ b/licenses_sub-deps.json
@@ -1,0 +1,4538 @@
+{
+  "@ampproject/remapping@2.3.0": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/ampproject/remapping",
+    "publisher": "Justin Ridgewell",
+    "email": "jridgewell@google.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@ampproject/remapping",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@ampproject/remapping/LICENSE"
+  },
+  "@babel/code-frame@7.26.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/code-frame",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/code-frame/LICENSE"
+  },
+  "@babel/compat-data@7.26.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/compat-data",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/compat-data/LICENSE"
+  },
+  "@babel/core@7.26.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/core/LICENSE"
+  },
+  "@babel/generator@7.26.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/generator",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/generator/LICENSE"
+  },
+  "@babel/helper-compilation-targets@7.26.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-compilation-targets",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-compilation-targets/LICENSE"
+  },
+  "@babel/helper-module-imports@7.25.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-module-imports",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-module-imports/LICENSE"
+  },
+  "@babel/helper-module-transforms@7.26.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-module-transforms",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-module-transforms/LICENSE"
+  },
+  "@babel/helper-plugin-utils@7.26.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-plugin-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-plugin-utils/LICENSE"
+  },
+  "@babel/helper-string-parser@7.25.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-string-parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-string-parser/LICENSE"
+  },
+  "@babel/helper-validator-identifier@7.25.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-validator-identifier",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-validator-identifier/LICENSE"
+  },
+  "@babel/helper-validator-option@7.25.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-validator-option",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helper-validator-option/LICENSE"
+  },
+  "@babel/helpers@7.26.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helpers",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/helpers/LICENSE"
+  },
+  "@babel/parser@7.26.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/parser/LICENSE"
+  },
+  "@babel/plugin-syntax-async-generators@7.8.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-async-generators",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-async-generators/LICENSE"
+  },
+  "@babel/plugin-syntax-bigint@7.8.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-bigint",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-bigint/LICENSE"
+  },
+  "@babel/plugin-syntax-class-properties@7.12.13": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-class-properties",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-class-properties/LICENSE"
+  },
+  "@babel/plugin-syntax-class-static-block@7.14.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-class-static-block",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-class-static-block/LICENSE"
+  },
+  "@babel/plugin-syntax-import-attributes@7.26.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-import-attributes",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-import-attributes/LICENSE"
+  },
+  "@babel/plugin-syntax-import-meta@7.10.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-import-meta",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-import-meta/LICENSE"
+  },
+  "@babel/plugin-syntax-json-strings@7.8.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-json-strings",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-json-strings/LICENSE"
+  },
+  "@babel/plugin-syntax-jsx@7.25.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-jsx",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-jsx/LICENSE"
+  },
+  "@babel/plugin-syntax-logical-assignment-operators@7.10.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-logical-assignment-operators",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-logical-assignment-operators/LICENSE"
+  },
+  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-nullish-coalescing-operator",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/LICENSE"
+  },
+  "@babel/plugin-syntax-numeric-separator@7.10.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-numeric-separator",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-numeric-separator/LICENSE"
+  },
+  "@babel/plugin-syntax-object-rest-spread@7.8.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-object-rest-spread",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-object-rest-spread/LICENSE"
+  },
+  "@babel/plugin-syntax-optional-catch-binding@7.8.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-optional-catch-binding",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-optional-catch-binding/LICENSE"
+  },
+  "@babel/plugin-syntax-optional-chaining@7.8.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-optional-chaining",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-optional-chaining/LICENSE"
+  },
+  "@babel/plugin-syntax-private-property-in-object@7.14.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-private-property-in-object",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-private-property-in-object/LICENSE"
+  },
+  "@babel/plugin-syntax-top-level-await@7.14.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-top-level-await",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-top-level-await/LICENSE"
+  },
+  "@babel/plugin-syntax-typescript@7.25.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-typescript",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/plugin-syntax-typescript/LICENSE"
+  },
+  "@babel/template@7.25.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/template",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/template/LICENSE"
+  },
+  "@babel/traverse@7.26.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/traverse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/traverse/LICENSE"
+  },
+  "@babel/types@7.26.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/babel/babel",
+    "publisher": "The Babel Team",
+    "url": "https://babel.dev/team",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@babel/types/LICENSE"
+  },
+  "@bcoe/v8-coverage@0.2.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/demurgos/v8-coverage",
+    "publisher": "Charles Samborski",
+    "email": "demurgos@demurgos.net",
+    "url": "https://demurgos.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@bcoe/v8-coverage",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@bcoe/v8-coverage/LICENSE.md"
+  },
+  "@cspotcode/source-map-support@0.8.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/cspotcode/node-source-map-support",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@cspotcode/source-map-support",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@cspotcode/source-map-support/LICENSE.md"
+  },
+  "@envelop/core@5.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/n1ru4l/envelop",
+    "publisher": "Dotan Simha",
+    "email": "dotansimha@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@envelop/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@envelop/core/LICENSE"
+  },
+  "@envelop/types@5.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/n1ru4l/envelop",
+    "publisher": "Dotan Simha",
+    "email": "dotansimha@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@envelop/types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@envelop/types/LICENSE"
+  },
+  "@eslint-community/eslint-utils@4.4.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint-community/eslint-utils",
+    "publisher": "Toru Nagashima",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/eslint-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/eslint-utils/LICENSE"
+  },
+  "@eslint-community/regexpp@4.12.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint-community/regexpp",
+    "publisher": "Toru Nagashima",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/regexpp",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint-community/regexpp/LICENSE"
+  },
+  "@eslint/config-array@0.19.2": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/config-array",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/config-array/LICENSE"
+  },
+  "@eslint/core@0.10.0": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/core/LICENSE"
+  },
+  "@eslint/eslintrc@3.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint/eslintrc",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/eslintrc",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/eslintrc/LICENSE"
+  },
+  "@eslint/js@9.19.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint/eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/js",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/js/LICENSE"
+  },
+  "@eslint/object-schema@2.1.6": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/object-schema",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/object-schema/LICENSE"
+  },
+  "@eslint/plugin-kit@0.2.5": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/rewrite",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/plugin-kit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@eslint/plugin-kit/LICENSE"
+  },
+  "@graphql-tools/executor@1.3.12": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/graphql-tools",
+    "publisher": "Saihajpreet Singh",
+    "email": "saihajpreet.singh@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/executor",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/executor/README.md"
+  },
+  "@graphql-tools/merge@9.0.17": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/graphql-tools",
+    "publisher": "Dotan Simha",
+    "email": "dotansimha@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/merge",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/merge/README.md"
+  },
+  "@graphql-tools/schema@10.0.16": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/graphql-tools",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/schema",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/schema/README.md"
+  },
+  "@graphql-tools/utils@10.7.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/graphql-tools",
+    "publisher": "Dotan Simha",
+    "email": "dotansimha@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-tools/utils"
+  },
+  "@graphql-typed-document-node/core@3.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dotansimha/graphql-typed-document-node",
+    "publisher": "Dotan Simha",
+    "email": "dotansimha@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-typed-document-node/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-typed-document-node/core/LICENSE"
+  },
+  "@graphql-yoga/logger@2.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dotansimha/graphql-yoga",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-yoga/logger",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-yoga/logger/LICENSE"
+  },
+  "@graphql-yoga/subscription@5.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dotansimha/graphql-yoga",
+    "publisher": "Laurin Quast",
+    "email": "laurinquast@googlemail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-yoga/subscription",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-yoga/subscription/LICENSE"
+  },
+  "@graphql-yoga/typed-event-target@3.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dotansimha/graphql-yoga",
+    "publisher": "Laurin Quast",
+    "email": "laurinquast@googlemail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-yoga/typed-event-target",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@graphql-yoga/typed-event-target/LICENSE"
+  },
+  "@humanfs/core@0.19.1": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/humanwhocodes/humanfs",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanfs/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanfs/core/LICENSE"
+  },
+  "@humanfs/node@0.16.6": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/humanwhocodes/humanfs",
+    "publisher": "Nicholas C. Zakas",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanfs/node",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanfs/node/LICENSE"
+  },
+  "@humanwhocodes/module-importer@1.0.1": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/humanwhocodes/module-importer",
+    "publisher": "Nicholas C. Zaks",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanwhocodes/module-importer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanwhocodes/module-importer/LICENSE"
+  },
+  "@humanwhocodes/retry@0.4.1": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/humanwhocodes/retry",
+    "publisher": "Nicholas C. Zaks",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanwhocodes/retry",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@humanwhocodes/retry/LICENSE"
+  },
+  "@istanbuljs/load-nyc-config@1.1.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/istanbuljs/load-nyc-config",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@istanbuljs/load-nyc-config",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@istanbuljs/load-nyc-config/LICENSE"
+  },
+  "@istanbuljs/schema@0.1.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/istanbuljs/schema",
+    "publisher": "Corey Farrell",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@istanbuljs/schema",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@istanbuljs/schema/LICENSE"
+  },
+  "@jest/console@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/console",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/console/LICENSE"
+  },
+  "@jest/core@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/core/LICENSE"
+  },
+  "@jest/environment@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/environment",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/environment/LICENSE"
+  },
+  "@jest/expect-utils@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/expect-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/expect-utils/LICENSE"
+  },
+  "@jest/expect@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/expect",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/expect/LICENSE"
+  },
+  "@jest/fake-timers@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/fake-timers",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/fake-timers/LICENSE"
+  },
+  "@jest/globals@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/globals",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/globals/LICENSE"
+  },
+  "@jest/reporters@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/reporters",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/reporters/LICENSE"
+  },
+  "@jest/schemas@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/schemas",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/schemas/LICENSE"
+  },
+  "@jest/source-map@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/source-map",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/source-map/LICENSE"
+  },
+  "@jest/test-result@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/test-result",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/test-result/LICENSE"
+  },
+  "@jest/test-sequencer@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/test-sequencer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/test-sequencer/LICENSE"
+  },
+  "@jest/transform@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/transform",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/transform/LICENSE"
+  },
+  "@jest/types@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jest/types/LICENSE"
+  },
+  "@jridgewell/gen-mapping@0.3.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jridgewell/gen-mapping",
+    "publisher": "Justin Ridgewell",
+    "email": "justin@ridgewell.name",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/gen-mapping",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/gen-mapping/LICENSE"
+  },
+  "@jridgewell/resolve-uri@3.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jridgewell/resolve-uri",
+    "publisher": "Justin Ridgewell",
+    "email": "justin@ridgewell.name",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/resolve-uri",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/resolve-uri/LICENSE"
+  },
+  "@jridgewell/set-array@1.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jridgewell/set-array",
+    "publisher": "Justin Ridgewell",
+    "email": "justin@ridgewell.name",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/set-array",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/set-array/LICENSE"
+  },
+  "@jridgewell/sourcemap-codec@1.5.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jridgewell/sourcemap-codec",
+    "publisher": "Rich Harris",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/sourcemap-codec",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/sourcemap-codec/LICENSE"
+  },
+  "@jridgewell/trace-mapping@0.3.25": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jridgewell/trace-mapping",
+    "publisher": "Justin Ridgewell",
+    "email": "justin@ridgewell.name",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/trace-mapping",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@jridgewell/trace-mapping/LICENSE"
+  },
+  "@napi-rs/nice-linux-x64-gnu@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Brooooooklyn/nice",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@napi-rs/nice-linux-x64-gnu",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@napi-rs/nice-linux-x64-gnu/README.md"
+  },
+  "@napi-rs/nice-linux-x64-musl@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Brooooooklyn/nice",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@napi-rs/nice-linux-x64-musl",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@napi-rs/nice-linux-x64-musl/README.md"
+  },
+  "@napi-rs/nice@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Brooooooklyn/nice",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@napi-rs/nice",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@napi-rs/nice/LICENSE"
+  },
+  "@nodelib/fs.scandir@2.1.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@nodelib/fs.scandir",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@nodelib/fs.scandir/LICENSE"
+  },
+  "@nodelib/fs.stat@2.0.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@nodelib/fs.stat",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@nodelib/fs.stat/LICENSE"
+  },
+  "@nodelib/fs.walk@1.2.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@nodelib/fs.walk",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@nodelib/fs.walk/LICENSE"
+  },
+  "@oxc-resolver/binding-linux-x64-gnu@1.12.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/oxc-project/oxc-resolver",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@oxc-resolver/binding-linux-x64-gnu",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@oxc-resolver/binding-linux-x64-gnu/README.md"
+  },
+  "@oxc-resolver/binding-linux-x64-musl@1.12.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/oxc-project/oxc-resolver",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@oxc-resolver/binding-linux-x64-musl",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@oxc-resolver/binding-linux-x64-musl/README.md"
+  },
+  "@repeaterjs/repeater@3.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/repeaterjs/repeater",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@repeaterjs/repeater",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@repeaterjs/repeater/README.md"
+  },
+  "@sec-ant/readable-stream@0.4.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Sec-ant/readable-stream",
+    "publisher": "Ze-Zheng Wu",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sec-ant/readable-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sec-ant/readable-stream/LICENSE"
+  },
+  "@sinclair/typebox@0.27.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sinclairzx81/typebox",
+    "publisher": "sinclairzx81",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sinclair/typebox",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sinclair/typebox/license"
+  },
+  "@sindresorhus/is@5.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/is",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sindresorhus/is",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sindresorhus/is/license"
+  },
+  "@sinonjs/commons@3.0.1": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/sinonjs/commons",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sinonjs/commons",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sinonjs/commons/LICENSE"
+  },
+  "@sinonjs/fake-timers@10.3.0": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/sinonjs/fake-timers",
+    "publisher": "Christian Johansen",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sinonjs/fake-timers",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@sinonjs/fake-timers/LICENSE"
+  },
+  "@swc-node/core@1.13.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/swc-project/swc-node",
+    "publisher": "LongYinan",
+    "email": "github@lyn.one",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/core/LICENSE"
+  },
+  "@swc-node/register@1.10.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/swc-project/swc-node",
+    "publisher": "LongYinan",
+    "email": "github@lyn.one",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/register",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/register/LICENSE"
+  },
+  "@swc-node/sourcemap-support@0.5.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/swc-project/swc-node",
+    "publisher": "LongYinan",
+    "email": "github@lyn.one",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/sourcemap-support",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc-node/sourcemap-support/LICENSE"
+  },
+  "@swc/cli@0.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/swc-project/pkgs",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/cli",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/cli/LICENSE"
+  },
+  "@swc/core-linux-x64-gnu@1.10.14": {
+    "licenses": "Apache-2.0 AND MIT",
+    "repository": "https://github.com/swc-project/swc",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/core-linux-x64-gnu",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/core-linux-x64-gnu/README.md"
+  },
+  "@swc/core-linux-x64-musl@1.10.14": {
+    "licenses": "Apache-2.0 AND MIT",
+    "repository": "https://github.com/swc-project/swc",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/core-linux-x64-musl",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/core-linux-x64-musl/README.md"
+  },
+  "@swc/core@1.10.14": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/swc-project/swc",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/core"
+  },
+  "@swc/counter@0.1.3": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/swc-project/pkgs",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/counter",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/counter/README.md"
+  },
+  "@swc/types@0.1.17": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/swc-project/swc",
+    "publisher": "강동윤",
+    "email": "kdy1997.dev@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@swc/types/LICENSE"
+  },
+  "@szmarczak/http-timer@5.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/szmarczak/http-timer",
+    "publisher": "Szymon Marczak",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@szmarczak/http-timer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@szmarczak/http-timer/LICENSE"
+  },
+  "@tokenizer/token@0.3.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Borewit/tokenizer-token",
+    "publisher": "Borewit",
+    "url": "https://github.com/Borewit",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tokenizer/token",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tokenizer/token/README.md"
+  },
+  "@tsconfig/node10@1.0.11": {
+    "licenses": "MIT",
+    "repository": "https://github.com/tsconfig/bases",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node10",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node10/LICENSE"
+  },
+  "@tsconfig/node12@1.0.11": {
+    "licenses": "MIT",
+    "repository": "https://github.com/tsconfig/bases",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node12",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node12/LICENSE"
+  },
+  "@tsconfig/node14@1.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/tsconfig/bases",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node14",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node14/LICENSE"
+  },
+  "@tsconfig/node16@1.0.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/tsconfig/bases",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node16",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@tsconfig/node16/LICENSE"
+  },
+  "@types/babel__core@7.20.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__core/LICENSE"
+  },
+  "@types/babel__generator@7.6.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__generator",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__generator/LICENSE"
+  },
+  "@types/babel__template@7.4.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__template",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__template/LICENSE"
+  },
+  "@types/babel__traverse@7.20.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__traverse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/babel__traverse/LICENSE"
+  },
+  "@types/body-parser@1.19.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/body-parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/body-parser/LICENSE"
+  },
+  "@types/connect@3.4.38": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/connect",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/connect/LICENSE"
+  },
+  "@types/cookiejar@2.1.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/cookiejar",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/cookiejar/LICENSE"
+  },
+  "@types/cors@2.8.17": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/cors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/cors/LICENSE"
+  },
+  "@types/estree@1.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/estree",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/estree/LICENSE"
+  },
+  "@types/express-serve-static-core@5.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/express-serve-static-core",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/express-serve-static-core/LICENSE"
+  },
+  "@types/express@5.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/express",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/express/LICENSE"
+  },
+  "@types/graceful-fs@4.1.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/graceful-fs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/graceful-fs/LICENSE"
+  },
+  "@types/http-cache-semantics@4.0.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/http-cache-semantics",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/http-cache-semantics/LICENSE"
+  },
+  "@types/http-errors@2.0.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/http-errors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/http-errors/LICENSE"
+  },
+  "@types/istanbul-lib-coverage@2.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/istanbul-lib-coverage",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/istanbul-lib-coverage/LICENSE"
+  },
+  "@types/istanbul-lib-report@3.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/istanbul-lib-report",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/istanbul-lib-report/LICENSE"
+  },
+  "@types/istanbul-reports@3.0.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/istanbul-reports",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/istanbul-reports/LICENSE"
+  },
+  "@types/jest@29.5.14": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/jest/LICENSE"
+  },
+  "@types/json-schema@7.0.15": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/json-schema",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/json-schema/LICENSE"
+  },
+  "@types/methods@1.1.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/methods",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/methods/LICENSE"
+  },
+  "@types/mime@1.3.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/mime",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/mime/LICENSE"
+  },
+  "@types/morgan@1.9.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/morgan",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/morgan/LICENSE"
+  },
+  "@types/node@22.13.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/node",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/node/LICENSE"
+  },
+  "@types/qs@6.9.18": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/qs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/qs/LICENSE"
+  },
+  "@types/range-parser@1.2.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/range-parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/range-parser/LICENSE"
+  },
+  "@types/send@0.17.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/send",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/send/LICENSE"
+  },
+  "@types/serve-static@1.15.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/serve-static",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/serve-static/LICENSE"
+  },
+  "@types/stack-utils@2.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/stack-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/stack-utils/LICENSE"
+  },
+  "@types/superagent@8.1.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/superagent",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/superagent/LICENSE"
+  },
+  "@types/supertest@6.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/supertest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/supertest/LICENSE"
+  },
+  "@types/yargs-parser@21.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/yargs-parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/yargs-parser/LICENSE"
+  },
+  "@types/yargs@17.0.33": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/yargs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@types/yargs/LICENSE"
+  },
+  "@typescript-eslint/eslint-plugin@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/eslint-plugin",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/eslint-plugin/LICENSE"
+  },
+  "@typescript-eslint/parser@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/parser/LICENSE"
+  },
+  "@typescript-eslint/scope-manager@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/scope-manager",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/scope-manager/LICENSE"
+  },
+  "@typescript-eslint/type-utils@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/type-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/type-utils/LICENSE"
+  },
+  "@typescript-eslint/types@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/types/LICENSE"
+  },
+  "@typescript-eslint/typescript-estree@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/typescript-estree",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/typescript-estree/LICENSE"
+  },
+  "@typescript-eslint/utils@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/utils/LICENSE"
+  },
+  "@typescript-eslint/visitor-keys@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/visitor-keys",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@typescript-eslint/visitor-keys/LICENSE"
+  },
+  "@whatwg-node/disposablestack@0.0.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/whatwg-node",
+    "publisher": "Arda TANRIKULU",
+    "email": "ardatanrikulu@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/disposablestack"
+  },
+  "@whatwg-node/events@0.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/whatwg-node",
+    "publisher": "Arda TANRIKULU",
+    "email": "ardatanrikulu@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/events",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/events/README.md"
+  },
+  "@whatwg-node/fetch@0.10.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/whatwg-node",
+    "publisher": "Arda TANRIKULU",
+    "email": "ardatanrikulu@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/fetch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/fetch/README.md"
+  },
+  "@whatwg-node/node-fetch@0.7.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/whatwg-node",
+    "publisher": "Arda TANRIKULU",
+    "email": "ardatanrikulu@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/node-fetch"
+  },
+  "@whatwg-node/server@0.9.66": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/whatwg-node",
+    "publisher": "Arda TANRIKULU",
+    "email": "ardatanrikulu@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/server",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@whatwg-node/server/README.md"
+  },
+  "@xhmikosr/archive-type@7.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/archive-type",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/archive-type",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/archive-type/license"
+  },
+  "@xhmikosr/bin-check@7.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/bin-check",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/bin-check",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/bin-check/license"
+  },
+  "@xhmikosr/bin-wrapper@13.0.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/bin-wrapper",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/bin-wrapper",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/bin-wrapper/license"
+  },
+  "@xhmikosr/decompress-tar@8.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/decompress-tar",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-tar",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-tar/license"
+  },
+  "@xhmikosr/decompress-tarbz2@8.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/decompress-tarbz2",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-tarbz2",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-tarbz2/license"
+  },
+  "@xhmikosr/decompress-targz@8.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/decompress-targz",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-targz",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-targz/license"
+  },
+  "@xhmikosr/decompress-unzip@7.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/decompress-unzip",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-unzip",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress-unzip/license"
+  },
+  "@xhmikosr/decompress@10.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/decompress",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/decompress/license"
+  },
+  "@xhmikosr/downloader@15.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/download",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/downloader",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/downloader/license"
+  },
+  "@xhmikosr/os-filter-obj@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/XhmikosR/os-filter-obj",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/os-filter-obj",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/@xhmikosr/os-filter-obj/license"
+  },
+  "abbrev@1.1.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/abbrev-js",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/abbrev",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/abbrev/LICENSE"
+  },
+  "accepts@1.3.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/accepts",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/accepts",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/accepts/LICENSE"
+  },
+  "acorn-jsx@5.3.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/acornjs/acorn-jsx",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/acorn-jsx",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/acorn-jsx/LICENSE"
+  },
+  "acorn-walk@8.3.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/acornjs/acorn",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/acorn-walk",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/acorn-walk/LICENSE"
+  },
+  "acorn@8.14.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/acornjs/acorn",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/acorn",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/acorn/LICENSE"
+  },
+  "ajv@6.12.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ajv-validator/ajv",
+    "publisher": "Evgeny Poberezkin",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ajv",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ajv/LICENSE"
+  },
+  "ansi-escapes@4.3.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/ansi-escapes",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ansi-escapes",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ansi-escapes/license"
+  },
+  "ansi-regex@5.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chalk/ansi-regex",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ansi-regex",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ansi-regex/license"
+  },
+  "ansi-styles@3.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chalk/ansi-styles",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ansi-styles",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ansi-styles/license"
+  },
+  "anymatch@3.1.3": {
+    "licenses": "ISC",
+    "repository": "https://github.com/micromatch/anymatch",
+    "publisher": "Elan Shanker",
+    "url": "https://github.com/es128",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/anymatch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/anymatch/LICENSE"
+  },
+  "arch@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/feross/arch",
+    "publisher": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/arch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/arch/LICENSE"
+  },
+  "arg@4.1.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/zeit/arg",
+    "publisher": "Josh Junon",
+    "email": "junon@zeit.co",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/arg",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/arg/LICENSE.md"
+  },
+  "argparse@2.0.1": {
+    "licenses": "Python-2.0",
+    "repository": "https://github.com/nodeca/argparse",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/argparse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/argparse/LICENSE"
+  },
+  "array-find-index@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/array-find-index",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/array-find-index",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/array-find-index/license"
+  },
+  "array-flatten@1.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/blakeembrey/array-flatten",
+    "publisher": "Blake Embrey",
+    "email": "hello@blakeembrey.com",
+    "url": "http://blakeembrey.me",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/array-flatten",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/array-flatten/LICENSE"
+  },
+  "asap@2.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kriskowal/asap",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/asap",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/asap/LICENSE.md"
+  },
+  "async@3.2.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/caolan/async",
+    "publisher": "Caolan McMahon",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/async",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/async/LICENSE"
+  },
+  "asynckit@0.4.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/alexindigo/asynckit",
+    "publisher": "Alex Indigo",
+    "email": "iam@alexindigo.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/asynckit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/asynckit/LICENSE"
+  },
+  "b4a@1.6.7": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/holepunchto/b4a",
+    "publisher": "Holepunch",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/b4a",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/b4a/LICENSE"
+  },
+  "babel-jest@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-jest/LICENSE"
+  },
+  "babel-plugin-istanbul@6.1.1": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/istanbuljs/babel-plugin-istanbul",
+    "publisher": "Thai Pangsakulyanont @dtinth",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-plugin-istanbul",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-plugin-istanbul/LICENSE"
+  },
+  "babel-plugin-jest-hoist@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-plugin-jest-hoist",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-plugin-jest-hoist/LICENSE"
+  },
+  "babel-preset-current-node-syntax@1.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax",
+    "publisher": "Nicolò Ribaudo",
+    "url": "https://github.com/nicolo-ribaudo",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-preset-current-node-syntax",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-preset-current-node-syntax/LICENSE"
+  },
+  "babel-preset-jest@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-preset-jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/babel-preset-jest/LICENSE"
+  },
+  "balanced-match@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/juliangruber/balanced-match",
+    "publisher": "Julian Gruber",
+    "email": "mail@juliangruber.com",
+    "url": "http://juliangruber.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/balanced-match",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/balanced-match/LICENSE.md"
+  },
+  "bare-events@2.5.4": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/holepunchto/bare-events",
+    "publisher": "Holepunch",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bare-events",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bare-events/LICENSE"
+  },
+  "base64-js@1.5.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/beatgammit/base64-js",
+    "publisher": "T. Jameson Little",
+    "email": "t.jameson.little@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/base64-js",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/base64-js/LICENSE"
+  },
+  "basic-auth@2.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/basic-auth",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/basic-auth",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/basic-auth/LICENSE"
+  },
+  "bin-version-check@5.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/bin-version-check",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bin-version-check",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bin-version-check/license"
+  },
+  "bin-version@6.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/bin-version",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bin-version",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bin-version/license"
+  },
+  "binary-extensions@2.3.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/binary-extensions",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/binary-extensions",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/binary-extensions/license"
+  },
+  "body-parser@1.20.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/expressjs/body-parser",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/body-parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/body-parser/LICENSE"
+  },
+  "brace-expansion@1.1.11": {
+    "licenses": "MIT",
+    "repository": "https://github.com/juliangruber/brace-expansion",
+    "publisher": "Julian Gruber",
+    "email": "mail@juliangruber.com",
+    "url": "http://juliangruber.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/brace-expansion",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/brace-expansion/LICENSE"
+  },
+  "braces@3.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/micromatch/braces",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/braces",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/braces/LICENSE"
+  },
+  "browserslist@4.24.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/browserslist/browserslist",
+    "publisher": "Andrey Sitnik",
+    "email": "andrey@sitnik.ru",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/browserslist",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/browserslist/LICENSE"
+  },
+  "bs-logger@0.2.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/huafu/bs-logger",
+    "publisher": "Huafu Gandon",
+    "email": "huafu.gandon@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bs-logger",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bs-logger/LICENSE"
+  },
+  "bser@2.1.1": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/facebook/watchman",
+    "publisher": "Wez Furlong",
+    "email": "wez@fb.com",
+    "url": "http://wezfurlong.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bser/README.md"
+  },
+  "buffer-crc32@0.2.13": {
+    "licenses": "MIT",
+    "repository": "https://github.com/brianloveswords/buffer-crc32",
+    "publisher": "Brian J. Brennan",
+    "email": "brianloveswords@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/buffer-crc32",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/buffer-crc32/LICENSE"
+  },
+  "buffer-from@1.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/LinusU/buffer-from",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/buffer-from",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/buffer-from/LICENSE"
+  },
+  "buffer@5.7.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/feross/buffer",
+    "publisher": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/buffer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/buffer/LICENSE"
+  },
+  "busboy@1.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mscdex/busboy",
+    "publisher": "Brian White",
+    "email": "mscdex@mscdex.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/busboy",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/busboy/LICENSE"
+  },
+  "bytes@3.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/visionmedia/bytes.js",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "url": "http://tjholowaychuk.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bytes",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/bytes/LICENSE"
+  },
+  "cacheable-lookup@7.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/szmarczak/cacheable-lookup",
+    "publisher": "Szymon Marczak",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cacheable-lookup",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cacheable-lookup/LICENSE"
+  },
+  "cacheable-request@10.2.14": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jaredwray/cacheable",
+    "publisher": "Jared Wray",
+    "email": "me@jaredwray.com",
+    "url": "http://jaredwray.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cacheable-request",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cacheable-request/README.md"
+  },
+  "call-bind-apply-helpers@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/call-bind-apply-helpers",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/call-bind-apply-helpers",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/call-bind-apply-helpers/LICENSE"
+  },
+  "call-bound@1.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/call-bound",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/call-bound",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/call-bound/LICENSE"
+  },
+  "callsites@3.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/callsites",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/callsites",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/callsites/license"
+  },
+  "camelcase@6.3.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/camelcase",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/camelcase",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/camelcase/license"
+  },
+  "caniuse-lite@1.0.30001697": {
+    "licenses": "CC-BY-4.0",
+    "repository": "https://github.com/browserslist/caniuse-lite",
+    "publisher": "Ben Briggs",
+    "email": "beneb.info@gmail.com",
+    "url": "http://beneb.info",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/caniuse-lite",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/caniuse-lite/LICENSE"
+  },
+  "chalk@4.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chalk/chalk",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/chalk",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/chalk/license"
+  },
+  "char-regex@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Richienb/char-regex",
+    "publisher": "Richie Bendall",
+    "email": "richiebendall@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/char-regex",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/char-regex/LICENSE"
+  },
+  "chokidar@3.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/paulmillr/chokidar",
+    "publisher": "Paul Miller",
+    "url": "https://paulmillr.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/chokidar",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/chokidar/LICENSE"
+  },
+  "ci-info@3.9.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/watson/ci-info",
+    "publisher": "Thomas Watson Steen",
+    "email": "w@tson.dk",
+    "url": "https://twitter.com/wa7son",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ci-info",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ci-info/LICENSE"
+  },
+  "cjs-module-lexer@1.4.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nodejs/cjs-module-lexer",
+    "publisher": "Guy Bedford",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cjs-module-lexer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cjs-module-lexer/LICENSE"
+  },
+  "cliui@8.0.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/yargs/cliui",
+    "publisher": "Ben Coe",
+    "email": "ben@npmjs.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cliui",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cliui/LICENSE.txt"
+  },
+  "co@4.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/tj/co",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/co",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/co/LICENSE"
+  },
+  "collect-v8-coverage@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/SimenB/collect-v8-coverage",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/collect-v8-coverage",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/collect-v8-coverage/LICENSE"
+  },
+  "color-convert@1.9.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Qix-/color-convert",
+    "publisher": "Heather Arthur",
+    "email": "fayearthur@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/color-convert",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/color-convert/LICENSE"
+  },
+  "color-name@1.1.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dfcreative/color-name",
+    "publisher": "DY",
+    "email": "dfcreative@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/color-name",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/color-name/LICENSE"
+  },
+  "colorette@2.0.20": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jorgebucaran/colorette",
+    "publisher": "Jorge Bucaran",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/colorette",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/colorette/LICENSE.md"
+  },
+  "combined-stream@1.0.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/felixge/node-combined-stream",
+    "publisher": "Felix Geisendörfer",
+    "email": "felix@debuggable.com",
+    "url": "http://debuggable.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/combined-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/combined-stream/License"
+  },
+  "commander@8.3.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/tj/commander.js",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/commander",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/commander/LICENSE"
+  },
+  "component-emitter@1.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/component-emitter",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/component-emitter",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/component-emitter/LICENSE"
+  },
+  "concat-map@0.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/substack/node-concat-map",
+    "publisher": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/concat-map",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/concat-map/LICENSE"
+  },
+  "content-disposition@0.5.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/content-disposition",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/content-disposition",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/content-disposition/LICENSE"
+  },
+  "content-type@1.0.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/content-type",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/content-type",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/content-type/LICENSE"
+  },
+  "convert-source-map@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/thlorenz/convert-source-map",
+    "publisher": "Thorsten Lorenz",
+    "email": "thlorenz@gmx.de",
+    "url": "http://thlorenz.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/convert-source-map",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/convert-source-map/LICENSE"
+  },
+  "cookie-signature@1.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/visionmedia/node-cookie-signature",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@learnboost.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cookie-signature",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cookie-signature/Readme.md"
+  },
+  "cookie@0.7.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/cookie",
+    "publisher": "Roman Shtylman",
+    "email": "shtylman@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cookie",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cookie/LICENSE"
+  },
+  "cookiejar@2.1.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/bmeck/node-cookiejar",
+    "publisher": "bradleymeck",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cookiejar",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cookiejar/LICENSE"
+  },
+  "create-jest@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/create-jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/create-jest/LICENSE"
+  },
+  "create-require@1.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nuxt-contrib/create-require",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/create-require",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/create-require/LICENSE"
+  },
+  "cross-inspect@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ardatan/graphql-tools",
+    "publisher": "Arda TANRIKULU",
+    "email": "ardatanrikulu@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cross-inspect"
+  },
+  "cross-spawn@7.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/moxystudio/node-cross-spawn",
+    "publisher": "André Cruz",
+    "email": "andre@moxy.studio",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cross-spawn",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/cross-spawn/LICENSE"
+  },
+  "debug@4.4.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/debug-js/debug",
+    "publisher": "Josh Junon",
+    "url": "https://github.com/qix-",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/debug",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/debug/LICENSE"
+  },
+  "debuglog@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sam-github/node-debuglog",
+    "publisher": "Sam Roberts",
+    "email": "sam@strongloop.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/debuglog",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/debuglog/LICENSE"
+  },
+  "decompress-response@6.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/decompress-response",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/decompress-response",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/decompress-response/license"
+  },
+  "dedent@1.5.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dmnd/dedent",
+    "publisher": "Desmond Brand",
+    "email": "dmnd@desmondbrand.com",
+    "url": "http://desmondbrand.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dedent",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dedent/LICENSE.md"
+  },
+  "deep-is@0.1.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/thlorenz/deep-is",
+    "publisher": "Thorsten Lorenz",
+    "email": "thlorenz@gmx.de",
+    "url": "http://thlorenz.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/deep-is",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/deep-is/LICENSE"
+  },
+  "deepmerge@4.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/TehShrike/deepmerge",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/deepmerge",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/deepmerge/license.txt"
+  },
+  "defaults@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/node-defaults",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/defaults",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/defaults/license"
+  },
+  "defer-to-connect@2.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/szmarczak/defer-to-connect",
+    "publisher": "Szymon Marczak",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/defer-to-connect",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/defer-to-connect/LICENSE"
+  },
+  "delayed-stream@1.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/felixge/node-delayed-stream",
+    "publisher": "Felix Geisendörfer",
+    "email": "felix@debuggable.com",
+    "url": "http://debuggable.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/delayed-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/delayed-stream/License"
+  },
+  "depd@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dougwilson/nodejs-depd",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/depd",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/depd/LICENSE"
+  },
+  "destroy@1.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/stream-utils/destroy",
+    "publisher": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/destroy",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/destroy/LICENSE"
+  },
+  "detect-newline@3.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/detect-newline",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/detect-newline",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/detect-newline/license"
+  },
+  "dezalgo@1.0.4": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/dezalgo",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dezalgo",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dezalgo/LICENSE"
+  },
+  "diff-sequences@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/diff-sequences",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/diff-sequences/LICENSE"
+  },
+  "diff@4.0.2": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/kpdecker/jsdiff",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/diff",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/diff/LICENSE"
+  },
+  "dotenv@16.4.7": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/motdotla/dotenv",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dotenv",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dotenv/LICENSE"
+  },
+  "dset@3.1.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lukeed/dset",
+    "publisher": "Luke Edwards",
+    "email": "luke.edwards05@gmail.com",
+    "url": "https://lukeed.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dset",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dset/license"
+  },
+  "dunder-proto@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/es-shims/dunder-proto",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dunder-proto",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/dunder-proto/LICENSE"
+  },
+  "ee-first@1.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jonathanong/ee-first",
+    "publisher": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ee-first",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ee-first/LICENSE"
+  },
+  "ejs@3.1.10": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/mde/ejs",
+    "publisher": "Matthew Eernisse",
+    "email": "mde@fleegix.org",
+    "url": "http://fleegix.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ejs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ejs/LICENSE"
+  },
+  "electron-to-chromium@1.5.95": {
+    "licenses": "ISC",
+    "repository": "https://github.com/kilian/electron-to-chromium",
+    "publisher": "Kilian Valkhof",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/electron-to-chromium",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/electron-to-chromium/LICENSE"
+  },
+  "emittery@0.13.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/emittery",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/emittery",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/emittery/license"
+  },
+  "emoji-regex@8.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mathiasbynens/emoji-regex",
+    "publisher": "Mathias Bynens",
+    "url": "https://mathiasbynens.be/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/emoji-regex",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/emoji-regex/LICENSE-MIT.txt"
+  },
+  "encodeurl@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/pillarjs/encodeurl",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/encodeurl",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/encodeurl/LICENSE"
+  },
+  "error-ex@1.3.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/qix-/node-error-ex",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/error-ex",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/error-ex/LICENSE"
+  },
+  "es-define-property@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/es-define-property",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/es-define-property",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/es-define-property/LICENSE"
+  },
+  "es-errors@1.3.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/es-errors",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/es-errors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/es-errors/LICENSE"
+  },
+  "es-object-atoms@1.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/es-object-atoms",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/es-object-atoms",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/es-object-atoms/LICENSE"
+  },
+  "escalade@3.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lukeed/escalade",
+    "publisher": "Luke Edwards",
+    "email": "luke.edwards05@gmail.com",
+    "url": "https://lukeed.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/escalade",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/escalade/license"
+  },
+  "escape-html@1.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/component/escape-html",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/escape-html",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/escape-html/LICENSE"
+  },
+  "escape-string-regexp@4.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/escape-string-regexp",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/escape-string-regexp",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/escape-string-regexp/license"
+  },
+  "eslint-scope@8.2.0": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/eslint/js",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-scope",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-scope/LICENSE"
+  },
+  "eslint-visitor-keys@4.2.0": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/eslint/js",
+    "publisher": "Toru Nagashima",
+    "url": "https://github.com/mysticatea",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-visitor-keys",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint-visitor-keys/LICENSE"
+  },
+  "eslint@9.19.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eslint/eslint",
+    "publisher": "Nicholas C. Zakas",
+    "email": "nicholas+npm@nczconsulting.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/eslint/LICENSE"
+  },
+  "espree@10.3.0": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/eslint/js",
+    "publisher": "Nicholas C. Zakas",
+    "email": "nicholas+npm@nczconsulting.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/espree",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/espree/LICENSE"
+  },
+  "esprima@4.0.1": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/jquery/esprima",
+    "publisher": "Ariya Hidayat",
+    "email": "ariya.hidayat@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esprima",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esprima/LICENSE.BSD"
+  },
+  "esquery@1.6.0": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/estools/esquery",
+    "publisher": "Joel Feenstra",
+    "email": "jrfeenst+esquery@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esquery",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esquery/license.txt"
+  },
+  "esrecurse@4.3.0": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/estools/esrecurse",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esrecurse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esrecurse/README.md"
+  },
+  "estraverse@5.3.0": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/estools/estraverse",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/estraverse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/estraverse/LICENSE.BSD"
+  },
+  "esutils@2.0.3": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/estools/esutils",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esutils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/esutils/LICENSE.BSD"
+  },
+  "etag@1.8.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/etag",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/etag",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/etag/LICENSE"
+  },
+  "execa@5.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/execa",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/execa",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/execa/license"
+  },
+  "exit@0.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/cowboy/node-exit",
+    "publisher": "\"Cowboy\" Ben Alman",
+    "url": "http://benalman.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/exit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/exit/LICENSE-MIT"
+  },
+  "expect@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/expect",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/expect/LICENSE"
+  },
+  "express-rate-limit@7.5.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/express-rate-limit/express-rate-limit",
+    "publisher": "Nathan Friedly",
+    "url": "http://nfriedly.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express-rate-limit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express-rate-limit/license.md"
+  },
+  "express@4.21.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/expressjs/express",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/express/LICENSE"
+  },
+  "ext-list@2.2.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kevva/ext-list",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ext-list",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ext-list/license"
+  },
+  "ext-name@5.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kevva/ext-name",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ext-name",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ext-name/license"
+  },
+  "fast-deep-equal@3.1.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/epoberezkin/fast-deep-equal",
+    "publisher": "Evgeny Poberezkin",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-deep-equal",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-deep-equal/LICENSE"
+  },
+  "fast-fifo@1.3.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mafintosh/fast-fifo",
+    "publisher": "Mathias Buus",
+    "url": "@mafintosh",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-fifo",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-fifo/LICENSE"
+  },
+  "fast-glob@3.3.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mrmlnc/fast-glob",
+    "publisher": "Denis Malinochkin",
+    "url": "https://mrmlnc.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-glob",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-glob/LICENSE"
+  },
+  "fast-json-stable-stringify@2.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/epoberezkin/fast-json-stable-stringify",
+    "publisher": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-json-stable-stringify",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-json-stable-stringify/LICENSE"
+  },
+  "fast-levenshtein@2.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/hiddentao/fast-levenshtein",
+    "publisher": "Ramesh Nair",
+    "email": "ram@hiddentao.com",
+    "url": "http://www.hiddentao.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-levenshtein",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-levenshtein/LICENSE.md"
+  },
+  "fast-safe-stringify@2.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/davidmarkclements/fast-safe-stringify",
+    "publisher": "David Mark Clements",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-safe-stringify",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fast-safe-stringify/LICENSE"
+  },
+  "fastq@1.19.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/mcollina/fastq",
+    "publisher": "Matteo Collina",
+    "email": "hello@matteocollina.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fastq",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fastq/LICENSE"
+  },
+  "fb-watchman@2.0.2": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/facebook/watchman",
+    "publisher": "Wez Furlong",
+    "email": "wez@fb.com",
+    "url": "http://wezfurlong.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fb-watchman",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fb-watchman/README.md"
+  },
+  "file-entry-cache@8.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jaredwray/file-entry-cache",
+    "publisher": "Jared Wray",
+    "url": "https://jaredwray.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/file-entry-cache",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/file-entry-cache/LICENSE"
+  },
+  "file-type@19.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/file-type",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/file-type",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/file-type/license"
+  },
+  "filelist@1.0.4": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/mde/filelist",
+    "publisher": "Matthew Eernisse",
+    "email": "mde@fleegix.org",
+    "url": "http://fleegix.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/filelist",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/filelist/README.md"
+  },
+  "filename-reserved-regex@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/filename-reserved-regex",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/filename-reserved-regex",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/filename-reserved-regex/license"
+  },
+  "filenamify@6.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/filenamify",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/filenamify",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/filenamify/license"
+  },
+  "fill-range@7.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jonschlinkert/fill-range",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fill-range",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fill-range/LICENSE"
+  },
+  "finalhandler@1.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/pillarjs/finalhandler",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/finalhandler",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/finalhandler/LICENSE"
+  },
+  "find-up@5.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/find-up",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/find-up",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/find-up/license"
+  },
+  "find-versions@5.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/find-versions",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/find-versions",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/find-versions/license"
+  },
+  "flat-cache@4.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jaredwray/flat-cache",
+    "publisher": "Jared Wray",
+    "url": "https://jaredwray.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/flat-cache",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/flat-cache/LICENSE"
+  },
+  "flatted@3.3.2": {
+    "licenses": "ISC",
+    "repository": "https://github.com/WebReflection/flatted",
+    "publisher": "Andrea Giammarchi",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/flatted",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/flatted/LICENSE"
+  },
+  "form-data-encoder@2.1.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/octet-stream/form-data-encoder",
+    "publisher": "Nick K.",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/form-data-encoder",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/form-data-encoder/license"
+  },
+  "form-data@4.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/form-data/form-data",
+    "publisher": "Felix Geisendörfer",
+    "email": "felix@debuggable.com",
+    "url": "http://debuggable.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/form-data",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/form-data/License"
+  },
+  "formidable@3.5.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/node-formidable/formidable",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/formidable",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/formidable/LICENSE"
+  },
+  "forwarded@0.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/forwarded",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/forwarded",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/forwarded/LICENSE"
+  },
+  "fresh@0.5.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/fresh",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "url": "http://tjholowaychuk.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fresh",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fresh/LICENSE"
+  },
+  "fs.realpath@1.0.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/fs.realpath",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fs.realpath",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/fs.realpath/LICENSE"
+  },
+  "function-bind@1.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Raynos/function-bind",
+    "publisher": "Raynos",
+    "email": "raynos2@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/function-bind",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/function-bind/LICENSE"
+  },
+  "gensync@1.0.0-beta.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/loganfsmyth/gensync",
+    "publisher": "Logan Smyth",
+    "email": "loganfsmyth@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/gensync",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/gensync/LICENSE"
+  },
+  "get-caller-file@2.0.5": {
+    "licenses": "ISC",
+    "repository": "https://github.com/stefanpenner/get-caller-file",
+    "publisher": "Stefan Penner",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-caller-file",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-caller-file/LICENSE.md"
+  },
+  "get-intrinsic@1.2.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/get-intrinsic",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-intrinsic",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-intrinsic/LICENSE"
+  },
+  "get-package-type@0.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/cfware/get-package-type",
+    "publisher": "Corey Farrell",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-package-type",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-package-type/LICENSE"
+  },
+  "get-proto@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/get-proto",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-proto",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-proto/LICENSE"
+  },
+  "get-stream@6.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/get-stream",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/get-stream/license"
+  },
+  "glob-parent@6.0.2": {
+    "licenses": "ISC",
+    "repository": "https://github.com/gulpjs/glob-parent",
+    "publisher": "Gulp Team",
+    "email": "team@gulpjs.com",
+    "url": "https://gulpjs.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/glob-parent",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/glob-parent/LICENSE"
+  },
+  "glob@7.2.3": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/node-glob",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/glob",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/glob/LICENSE"
+  },
+  "globals@15.14.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/globals",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/globals",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/globals/license"
+  },
+  "gopd@1.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/gopd",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/gopd",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/gopd/LICENSE"
+  },
+  "got@13.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/got",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/got",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/got/license"
+  },
+  "graceful-fs@4.2.11": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/node-graceful-fs",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graceful-fs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graceful-fs/LICENSE"
+  },
+  "graphemer@1.4.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/flmnt/graphemer",
+    "publisher": "Matt Davies",
+    "email": "matt@filament.so",
+    "url": "https://github.com/mattpauldavies",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphemer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphemer/LICENSE"
+  },
+  "graphql-tag@2.12.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/apollographql/graphql-tag",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-tag",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-tag/LICENSE"
+  },
+  "graphql-yoga@5.11.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dotansimha/graphql-yoga",
+    "publisher": "Saihajpreet Singh",
+    "email": "saihajpreet.singh@gmail.com",
+    "url": "https://saihaj.dev/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-yoga",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql-yoga/LICENSE"
+  },
+  "graphql@16.10.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/graphql/graphql-js",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/graphql/LICENSE"
+  },
+  "has-flag@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/has-flag",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/has-flag",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/has-flag/license"
+  },
+  "has-symbols@1.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/inspect-js/has-symbols",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "url": "http://ljharb.codes",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/has-symbols",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/has-symbols/LICENSE"
+  },
+  "hasown@2.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/inspect-js/hasOwn",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/hasown",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/hasown/LICENSE"
+  },
+  "helmet@8.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/helmetjs/helmet",
+    "publisher": "Adam Baldwin",
+    "email": "adam@npmjs.com",
+    "url": "https://evilpacket.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/helmet",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/helmet/LICENSE"
+  },
+  "hexoid@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lukeed/hexoid",
+    "publisher": "Luke Edwards",
+    "email": "luke.edwards05@gmail.com",
+    "url": "https://lukeed.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/hexoid",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/hexoid/license"
+  },
+  "hosted-git-info@2.8.9": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/hosted-git-info",
+    "publisher": "Rebecca Turner",
+    "email": "me@re-becca.org",
+    "url": "http://re-becca.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/hosted-git-info",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/hosted-git-info/LICENSE"
+  },
+  "html-escaper@2.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/WebReflection/html-escaper",
+    "publisher": "Andrea Giammarchi",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/html-escaper",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/html-escaper/LICENSE.txt"
+  },
+  "http-cache-semantics@4.1.1": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/kornelski/http-cache-semantics",
+    "publisher": "Kornel Lesiński",
+    "email": "kornel@geekhood.net",
+    "url": "https://kornel.ski/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/http-cache-semantics",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/http-cache-semantics/LICENSE"
+  },
+  "http-errors@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/http-errors",
+    "publisher": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/http-errors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/http-errors/LICENSE"
+  },
+  "http2-wrapper@2.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/szmarczak/http2-wrapper",
+    "publisher": "Szymon Marczak",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/http2-wrapper",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/http2-wrapper/LICENSE"
+  },
+  "human-signals@2.1.0": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/ehmicky/human-signals",
+    "publisher": "ehmicky",
+    "email": "ehmicky@gmail.com",
+    "url": "https://github.com/ehmicky",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/human-signals",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/human-signals/LICENSE"
+  },
+  "iconv-lite@0.4.24": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ashtuchkin/iconv-lite",
+    "publisher": "Alexander Shtuchkin",
+    "email": "ashtuchkin@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/iconv-lite",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/iconv-lite/LICENSE"
+  },
+  "ieee754@1.2.1": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/feross/ieee754",
+    "publisher": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ieee754",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ieee754/LICENSE"
+  },
+  "ignore-by-default@1.0.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/novemberborn/ignore-by-default",
+    "publisher": "Mark Wubben",
+    "url": "https://novemberborn.net/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ignore-by-default",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ignore-by-default/LICENSE"
+  },
+  "ignore@5.3.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kaelzhang/node-ignore",
+    "publisher": "kael",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ignore",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ignore/LICENSE-MIT"
+  },
+  "import-fresh@3.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/import-fresh",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/import-fresh",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/import-fresh/license"
+  },
+  "import-local@3.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/import-local",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/import-local",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/import-local/license"
+  },
+  "imurmurhash@0.1.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jensyt/imurmurhash-js",
+    "publisher": "Jens Taylor",
+    "email": "jensyt@gmail.com",
+    "url": "https://github.com/homebrewing",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/imurmurhash",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/imurmurhash/README.md"
+  },
+  "inflight@1.0.6": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/inflight",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/inflight",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/inflight/LICENSE"
+  },
+  "inherits@2.0.4": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/inherits",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/inherits",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/inherits/LICENSE"
+  },
+  "inspect-with-kind@1.0.5": {
+    "licenses": "ISC",
+    "repository": "https://github.com/shinnn/inspect-with-kind",
+    "publisher": "Shinnosuke Watanabe",
+    "url": "https://github.com/shinnn",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/inspect-with-kind",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/inspect-with-kind/LICENSE"
+  },
+  "ipaddr.js@1.9.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/whitequark/ipaddr.js",
+    "publisher": "whitequark",
+    "email": "whitequark@whitequark.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ipaddr.js",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ipaddr.js/LICENSE"
+  },
+  "is-arrayish@0.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/qix-/node-is-arrayish",
+    "publisher": "Qix",
+    "url": "http://github.com/qix-",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-arrayish",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-arrayish/LICENSE"
+  },
+  "is-binary-path@2.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/is-binary-path",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-binary-path",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-binary-path/license"
+  },
+  "is-core-module@2.16.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/inspect-js/is-core-module",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-core-module",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-core-module/LICENSE"
+  },
+  "is-extglob@2.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jonschlinkert/is-extglob",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-extglob",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-extglob/LICENSE"
+  },
+  "is-fullwidth-code-point@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/is-fullwidth-code-point",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-fullwidth-code-point",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-fullwidth-code-point/license"
+  },
+  "is-generator-fn@2.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/is-generator-fn",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-generator-fn",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-generator-fn/license"
+  },
+  "is-glob@4.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/micromatch/is-glob",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-glob",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-glob/LICENSE"
+  },
+  "is-number@7.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jonschlinkert/is-number",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-number",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-number/LICENSE"
+  },
+  "is-plain-obj@1.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/is-plain-obj",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-plain-obj",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-plain-obj/license"
+  },
+  "is-stream@2.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/is-stream",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/is-stream/license"
+  },
+  "isexe@2.0.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/isexe",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/isexe",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/isexe/LICENSE"
+  },
+  "istanbul-lib-coverage@3.2.2": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/istanbuljs/istanbuljs",
+    "publisher": "Krishnan Anantheswaran",
+    "email": "kananthmail-github@yahoo.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-coverage",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-coverage/LICENSE"
+  },
+  "istanbul-lib-instrument@6.0.3": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/istanbuljs/istanbuljs",
+    "publisher": "Krishnan Anantheswaran",
+    "email": "kananthmail-github@yahoo.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-instrument",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-instrument/LICENSE"
+  },
+  "istanbul-lib-report@3.0.1": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/istanbuljs/istanbuljs",
+    "publisher": "Krishnan Anantheswaran",
+    "email": "kananthmail-github@yahoo.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-report",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-report/LICENSE"
+  },
+  "istanbul-lib-source-maps@4.0.1": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/istanbuljs/istanbuljs",
+    "publisher": "Krishnan Anantheswaran",
+    "email": "kananthmail-github@yahoo.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-source-maps",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-lib-source-maps/LICENSE"
+  },
+  "istanbul-reports@3.1.7": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/istanbuljs/istanbuljs",
+    "publisher": "Krishnan Anantheswaran",
+    "email": "kananthmail-github@yahoo.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-reports",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/istanbul-reports/LICENSE"
+  },
+  "jake@10.9.2": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/jakejs/jake",
+    "publisher": "Matthew Eernisse",
+    "email": "mde@fleegix.org",
+    "url": "http://fleegix.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jake",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jake/README.md"
+  },
+  "jest-changed-files@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-changed-files",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-changed-files/LICENSE"
+  },
+  "jest-circus@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-circus",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-circus/LICENSE"
+  },
+  "jest-cli@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-cli",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-cli/LICENSE"
+  },
+  "jest-config@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-config",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-config/LICENSE"
+  },
+  "jest-diff@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-diff",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-diff/LICENSE"
+  },
+  "jest-docblock@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-docblock",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-docblock/LICENSE"
+  },
+  "jest-each@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "publisher": "Matt Phillips",
+    "url": "mattphillips",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-each",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-each/LICENSE"
+  },
+  "jest-environment-node@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-environment-node",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-environment-node/LICENSE"
+  },
+  "jest-get-type@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-get-type",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-get-type/LICENSE"
+  },
+  "jest-haste-map@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-haste-map",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-haste-map/LICENSE"
+  },
+  "jest-leak-detector@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-leak-detector",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-leak-detector/LICENSE"
+  },
+  "jest-matcher-utils@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-matcher-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-matcher-utils/LICENSE"
+  },
+  "jest-message-util@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-message-util",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-message-util/LICENSE"
+  },
+  "jest-mock@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-mock",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-mock/LICENSE"
+  },
+  "jest-pnp-resolver@1.2.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/arcanis/jest-pnp-resolver",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-pnp-resolver",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-pnp-resolver/README.md"
+  },
+  "jest-regex-util@29.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-regex-util",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-regex-util/LICENSE"
+  },
+  "jest-resolve-dependencies@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-resolve-dependencies",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-resolve-dependencies/LICENSE"
+  },
+  "jest-resolve@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-resolve",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-resolve/LICENSE"
+  },
+  "jest-runner@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-runner",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-runner/LICENSE"
+  },
+  "jest-runtime@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-runtime",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-runtime/LICENSE"
+  },
+  "jest-snapshot@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-snapshot",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-snapshot/LICENSE"
+  },
+  "jest-util@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-util",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-util/LICENSE"
+  },
+  "jest-validate@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-validate",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-validate/LICENSE"
+  },
+  "jest-watcher@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-watcher",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-watcher/LICENSE"
+  },
+  "jest-worker@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-worker",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest-worker/LICENSE"
+  },
+  "jest@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jest/LICENSE"
+  },
+  "js-tokens@4.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lydell/js-tokens",
+    "publisher": "Simon Lydell",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/js-tokens",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/js-tokens/LICENSE"
+  },
+  "js-yaml@4.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nodeca/js-yaml",
+    "publisher": "Vladimir Zapparov",
+    "email": "dervus.grim@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/js-yaml",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/js-yaml/LICENSE"
+  },
+  "jsesc@3.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mathiasbynens/jsesc",
+    "publisher": "Mathias Bynens",
+    "url": "https://mathiasbynens.be/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jsesc",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/jsesc/LICENSE-MIT.txt"
+  },
+  "json-buffer@3.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dominictarr/json-buffer",
+    "publisher": "Dominic Tarr",
+    "email": "dominic.tarr@gmail.com",
+    "url": "http://dominictarr.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-buffer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-buffer/LICENSE"
+  },
+  "json-parse-even-better-errors@2.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/npm/json-parse-even-better-errors",
+    "publisher": "Kat Marchán",
+    "email": "kzm@zkat.tech",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-parse-even-better-errors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-parse-even-better-errors/LICENSE.md"
+  },
+  "json-schema-traverse@0.4.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/epoberezkin/json-schema-traverse",
+    "publisher": "Evgeny Poberezkin",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-schema-traverse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-schema-traverse/LICENSE"
+  },
+  "json-stable-stringify-without-jsonify@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/samn/json-stable-stringify",
+    "publisher": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-stable-stringify-without-jsonify",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json-stable-stringify-without-jsonify/LICENSE"
+  },
+  "json5@2.2.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/json5/json5",
+    "publisher": "Aseem Kishore",
+    "email": "aseem.kishore@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json5",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/json5/LICENSE.md"
+  },
+  "keyv@4.5.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jaredwray/keyv",
+    "publisher": "Jared Wray",
+    "email": "me@jaredwray.com",
+    "url": "http://jaredwray.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/keyv",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/keyv/README.md"
+  },
+  "kind-of@6.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jonschlinkert/kind-of",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/kind-of",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/kind-of/LICENSE"
+  },
+  "kleur@3.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lukeed/kleur",
+    "publisher": "Luke Edwards",
+    "email": "luke.edwards05@gmail.com",
+    "url": "lukeed.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/kleur",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/kleur/license"
+  },
+  "leven@3.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/leven",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/leven",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/leven/license"
+  },
+  "levn@0.4.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/gkz/levn",
+    "publisher": "George Zahariev",
+    "email": "z@georgezahariev.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/levn",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/levn/LICENSE"
+  },
+  "license-checker@25.0.1": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/davglass/license-checker",
+    "publisher": "Dav Glass",
+    "email": "davglass@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/license-checker",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/license-checker/LICENSE"
+  },
+  "lines-and-columns@1.2.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/eventualbuddha/lines-and-columns",
+    "publisher": "Brian Donovan",
+    "email": "brian@donovans.cc",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lines-and-columns",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lines-and-columns/LICENSE"
+  },
+  "locate-path@6.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/locate-path",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/locate-path",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/locate-path/license"
+  },
+  "lodash.memoize@4.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lodash/lodash",
+    "publisher": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lodash.memoize",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lodash.memoize/LICENSE"
+  },
+  "lodash.merge@4.6.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lodash/lodash",
+    "publisher": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lodash.merge",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lodash.merge/LICENSE"
+  },
+  "lowercase-keys@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/lowercase-keys",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lowercase-keys",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lowercase-keys/license"
+  },
+  "lru-cache@10.4.3": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/node-lru-cache",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lru-cache",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/lru-cache/LICENSE"
+  },
+  "make-dir@4.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/make-dir",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/make-dir",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/make-dir/license"
+  },
+  "make-error@1.3.6": {
+    "licenses": "ISC",
+    "repository": "https://github.com/JsCommunity/make-error",
+    "publisher": "Julien Fontanet",
+    "email": "julien.fontanet@isonoe.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/make-error",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/make-error/LICENSE"
+  },
+  "makeerror@1.0.12": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/daaku/nodejs-makeerror",
+    "publisher": "Naitik Shah",
+    "email": "n@daaku.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/makeerror",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/makeerror/license"
+  },
+  "math-intrinsics@1.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/es-shims/math-intrinsics",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/math-intrinsics",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/math-intrinsics/LICENSE"
+  },
+  "media-typer@0.3.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/media-typer",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/media-typer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/media-typer/LICENSE"
+  },
+  "merge-descriptors@1.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/merge-descriptors",
+    "publisher": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/merge-descriptors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/merge-descriptors/LICENSE"
+  },
+  "merge-stream@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/grncdr/merge-stream",
+    "publisher": "Stephen Sugden",
+    "email": "me@stephensugden.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/merge-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/merge-stream/LICENSE"
+  },
+  "merge2@1.4.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/teambition/merge2",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/merge2",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/merge2/LICENSE"
+  },
+  "methods@1.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/methods",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/methods",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/methods/LICENSE"
+  },
+  "micromatch@4.0.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/micromatch/micromatch",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/micromatch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/micromatch/LICENSE"
+  },
+  "mime-db@1.52.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/mime-db",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mime-db",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mime-db/LICENSE"
+  },
+  "mime-types@2.1.35": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/mime-types",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mime-types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mime-types/LICENSE"
+  },
+  "mime@1.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/broofa/node-mime",
+    "publisher": "Robert Kieffer",
+    "email": "robert@broofa.com",
+    "url": "http://github.com/broofa",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mime",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mime/LICENSE"
+  },
+  "mimic-fn@2.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/mimic-fn",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mimic-fn",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mimic-fn/license"
+  },
+  "mimic-response@4.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/mimic-response",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mimic-response",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mimic-response/license"
+  },
+  "minimatch@9.0.5": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/minimatch",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/minimatch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/minimatch/LICENSE"
+  },
+  "minimist@1.2.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/minimistjs/minimist",
+    "publisher": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/minimist",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/minimist/LICENSE"
+  },
+  "mkdirp@0.5.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/substack/node-mkdirp",
+    "publisher": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mkdirp",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/mkdirp/LICENSE"
+  },
+  "morgan@1.10.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/expressjs/morgan",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/morgan",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/morgan/LICENSE"
+  },
+  "ms@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/zeit/ms",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ms",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ms/license.md"
+  },
+  "natural-compare@1.4.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/litejs/natural-compare-lite",
+    "publisher": "Lauri Rooden",
+    "url": "https://github.com/litejs/natural-compare-lite",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/natural-compare",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/natural-compare/README.md"
+  },
+  "negotiator@0.6.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/negotiator",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/negotiator",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/negotiator/LICENSE"
+  },
+  "node-graphql-code-test@1.0.0": {
+    "licenses": "Custom: https://github.com/swc-project/swc-node",
+    "publisher": "mattfsourcecode",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/README.md"
+  },
+  "node-int64@0.4.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/broofa/node-int64",
+    "publisher": "Robert Kieffer",
+    "email": "robert@broofa.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/node-int64",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/node-int64/LICENSE"
+  },
+  "node-releases@2.0.19": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chicoxyzzy/node-releases",
+    "publisher": "Sergey Rubanov",
+    "email": "chi187@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/node-releases",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/node-releases/LICENSE"
+  },
+  "nodemon@3.1.9": {
+    "licenses": "MIT",
+    "repository": "https://github.com/remy/nodemon",
+    "publisher": "Remy Sharp",
+    "url": "https://github.com/remy",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/nodemon",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/nodemon/LICENSE"
+  },
+  "nopt@4.0.3": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/nopt",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/nopt",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/nopt/LICENSE"
+  },
+  "normalize-package-data@2.5.0": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/npm/normalize-package-data",
+    "publisher": "Meryn Stol",
+    "email": "merynstol@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/normalize-package-data",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/normalize-package-data/LICENSE"
+  },
+  "normalize-path@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jonschlinkert/normalize-path",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/normalize-path",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/normalize-path/LICENSE"
+  },
+  "normalize-url@8.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/normalize-url",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/normalize-url",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/normalize-url/license"
+  },
+  "npm-normalize-package-bin@1.0.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/npm-normalize-package-bin",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "https://izs.me",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/npm-normalize-package-bin",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/npm-normalize-package-bin/LICENSE"
+  },
+  "npm-run-path@4.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/npm-run-path",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/npm-run-path",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/npm-run-path/license"
+  },
+  "object-inspect@1.13.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/inspect-js/object-inspect",
+    "publisher": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/object-inspect",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/object-inspect/LICENSE"
+  },
+  "on-finished@2.4.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/on-finished",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/on-finished",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/on-finished/LICENSE"
+  },
+  "on-headers@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/on-headers",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/on-headers",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/on-headers/LICENSE"
+  },
+  "once@1.4.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/once",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/once",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/once/LICENSE"
+  },
+  "onetime@5.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/onetime",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/onetime",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/onetime/license"
+  },
+  "optionator@0.9.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/gkz/optionator",
+    "publisher": "George Zahariev",
+    "email": "z@georgezahariev.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/optionator",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/optionator/LICENSE"
+  },
+  "os-homedir@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/os-homedir",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/os-homedir",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/os-homedir/license"
+  },
+  "os-tmpdir@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/os-tmpdir",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/os-tmpdir",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/os-tmpdir/license"
+  },
+  "osenv@0.1.5": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/osenv",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/osenv",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/osenv/LICENSE"
+  },
+  "oxc-resolver@1.12.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/oxc-project/oxc-resolver",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/oxc-resolver",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/oxc-resolver/README.md"
+  },
+  "p-cancelable@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/p-cancelable",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-cancelable",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-cancelable/license"
+  },
+  "p-limit@3.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/p-limit",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-limit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-limit/license"
+  },
+  "p-locate@5.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/p-locate",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-locate",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-locate/license"
+  },
+  "p-try@2.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/p-try",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-try",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/p-try/license"
+  },
+  "parent-module@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/parent-module",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/parent-module",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/parent-module/license"
+  },
+  "parse-json@5.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/parse-json",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/parse-json",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/parse-json/license"
+  },
+  "parseurl@1.3.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/pillarjs/parseurl",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/parseurl",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/parseurl/LICENSE"
+  },
+  "path-exists@4.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/path-exists",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-exists",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-exists/license"
+  },
+  "path-is-absolute@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/path-is-absolute",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-is-absolute",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-is-absolute/license"
+  },
+  "path-key@3.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/path-key",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-key",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-key/license"
+  },
+  "path-parse@1.0.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jbgutierrez/path-parse",
+    "publisher": "Javier Blanco",
+    "email": "http://jbgutierrez.info",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-parse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-parse/LICENSE"
+  },
+  "path-to-regexp@0.1.12": {
+    "licenses": "MIT",
+    "repository": "https://github.com/pillarjs/path-to-regexp",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-to-regexp",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/path-to-regexp/LICENSE"
+  },
+  "peek-readable@5.4.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Borewit/peek-readable",
+    "publisher": "Borewit",
+    "url": "https://github.com/Borewit",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/peek-readable",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/peek-readable/LICENSE"
+  },
+  "pend@1.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/andrewrk/node-pend",
+    "publisher": "Andrew Kelley",
+    "email": "superjoe30@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pend",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pend/LICENSE"
+  },
+  "picocolors@1.1.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/alexeyraspopov/picocolors",
+    "publisher": "Alexey Raspopov",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/picocolors",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/picocolors/LICENSE"
+  },
+  "picomatch@2.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/micromatch/picomatch",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/picomatch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/picomatch/LICENSE"
+  },
+  "pirates@4.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/danez/pirates",
+    "publisher": "Ari Porad",
+    "email": "ari@ariporad.com",
+    "url": "http://ariporad.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pirates",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pirates/LICENSE"
+  },
+  "piscina@4.8.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/piscinajs/piscina",
+    "publisher": "James M Snell",
+    "email": "jasnell@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/piscina",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/piscina/LICENSE"
+  },
+  "pkg-dir@4.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/pkg-dir",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pkg-dir",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pkg-dir/license"
+  },
+  "prelude-ls@1.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/gkz/prelude-ls",
+    "publisher": "George Zahariev",
+    "email": "z@georgezahariev.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/prelude-ls",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/prelude-ls/LICENSE"
+  },
+  "pretty-format@29.7.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jestjs/jest",
+    "publisher": "James Kyle",
+    "email": "me@thejameskyle.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pretty-format",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pretty-format/LICENSE"
+  },
+  "prompts@2.4.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/terkelg/prompts",
+    "publisher": "Terkel Gjervig",
+    "email": "terkel@terkel.com",
+    "url": "https://terkel.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/prompts",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/prompts/license"
+  },
+  "proxy-addr@2.0.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/proxy-addr",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/proxy-addr",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/proxy-addr/LICENSE"
+  },
+  "pstree.remy@1.1.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/remy/pstree",
+    "publisher": "Remy Sharp",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pstree.remy",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pstree.remy/LICENSE"
+  },
+  "punycode@2.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mathiasbynens/punycode.js",
+    "publisher": "Mathias Bynens",
+    "url": "https://mathiasbynens.be/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/punycode",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/punycode/LICENSE-MIT.txt"
+  },
+  "pure-rand@6.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dubzzz/pure-rand",
+    "publisher": "Nicolas DUBIEN",
+    "email": "github@dubien.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pure-rand",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/pure-rand/LICENSE"
+  },
+  "qs@6.13.0": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/ljharb/qs",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/qs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/qs/LICENSE.md"
+  },
+  "queue-microtask@1.2.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/feross/queue-microtask",
+    "publisher": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/queue-microtask",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/queue-microtask/LICENSE"
+  },
+  "quick-lru@5.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/quick-lru",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/quick-lru",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/quick-lru/license"
+  },
+  "range-parser@1.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/range-parser",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "url": "http://tjholowaychuk.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/range-parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/range-parser/LICENSE"
+  },
+  "raw-body@2.5.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/stream-utils/raw-body",
+    "publisher": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/raw-body",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/raw-body/LICENSE"
+  },
+  "react-is@18.3.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/facebook/react",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/react-is",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/react-is/LICENSE"
+  },
+  "read-installed@4.0.3": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/read-installed",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/read-installed",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/read-installed/LICENSE"
+  },
+  "read-package-json@2.1.2": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/read-package-json",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/read-package-json",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/read-package-json/LICENSE"
+  },
+  "readdir-scoped-modules@1.1.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/readdir-scoped-modules",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/readdir-scoped-modules",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/readdir-scoped-modules/LICENSE"
+  },
+  "readdirp@3.6.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/paulmillr/readdirp",
+    "publisher": "Thorsten Lorenz",
+    "email": "thlorenz@gmx.de",
+    "url": "thlorenz.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/readdirp",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/readdirp/LICENSE"
+  },
+  "require-directory@2.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/troygoode/node-require-directory",
+    "publisher": "Troy Goode",
+    "email": "troygoode@gmail.com",
+    "url": "http://github.com/troygoode/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/require-directory",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/require-directory/LICENSE"
+  },
+  "resolve-alpn@1.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/szmarczak/resolve-alpn",
+    "publisher": "Szymon Marczak",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve-alpn",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve-alpn/LICENSE"
+  },
+  "resolve-cwd@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/resolve-cwd",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve-cwd",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve-cwd/license"
+  },
+  "resolve-from@4.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/resolve-from",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve-from",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve-from/license"
+  },
+  "resolve.exports@2.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/lukeed/resolve.exports",
+    "publisher": "Luke Edwards",
+    "email": "luke.edwards05@gmail.com",
+    "url": "https://lukeed.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve.exports",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve.exports/license"
+  },
+  "resolve@1.22.10": {
+    "licenses": "MIT",
+    "repository": "https://github.com/browserify/resolve",
+    "publisher": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/resolve/LICENSE"
+  },
+  "responselike@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/responselike",
+    "publisher": "Luke Childs",
+    "email": "lukechilds123@gmail.com",
+    "url": "https://lukechilds.co.uk",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/responselike",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/responselike/license"
+  },
+  "reusify@1.0.4": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mcollina/reusify",
+    "publisher": "Matteo Collina",
+    "email": "hello@matteocollina.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/reusify",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/reusify/LICENSE"
+  },
+  "run-parallel@1.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/feross/run-parallel",
+    "publisher": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/run-parallel",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/run-parallel/LICENSE"
+  },
+  "safe-buffer@5.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/feross/safe-buffer",
+    "publisher": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/safe-buffer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/safe-buffer/LICENSE"
+  },
+  "safer-buffer@2.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ChALkeR/safer-buffer",
+    "publisher": "Nikita Skovoroda",
+    "email": "chalkerx@gmail.com",
+    "url": "https://github.com/ChALkeR",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/safer-buffer",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/safer-buffer/LICENSE"
+  },
+  "seek-bzip@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/cscott/seek-bzip",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/seek-bzip",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/seek-bzip/LICENSE"
+  },
+  "semver-regex@4.0.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/semver-regex",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/semver-regex",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/semver-regex/license"
+  },
+  "semver-truncate@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/semver-truncate",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/semver-truncate",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/semver-truncate/license"
+  },
+  "semver@7.6.3": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/node-semver",
+    "publisher": "GitHub Inc.",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/semver",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/semver/LICENSE"
+  },
+  "send@0.19.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/pillarjs/send",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/send",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/send/LICENSE"
+  },
+  "serve-static@1.16.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/expressjs/serve-static",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/serve-static",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/serve-static/LICENSE"
+  },
+  "setprototypeof@1.2.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/wesleytodd/setprototypeof",
+    "publisher": "Wes Todd",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/setprototypeof",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/setprototypeof/LICENSE"
+  },
+  "shebang-command@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kevva/shebang-command",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/shebang-command",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/shebang-command/license"
+  },
+  "shebang-regex@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/shebang-regex",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/shebang-regex",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/shebang-regex/license"
+  },
+  "side-channel-list@1.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/side-channel-list",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel-list",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel-list/LICENSE"
+  },
+  "side-channel-map@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/side-channel-map",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel-map",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel-map/LICENSE"
+  },
+  "side-channel-weakmap@1.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/side-channel-weakmap",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel-weakmap",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel-weakmap/LICENSE"
+  },
+  "side-channel@1.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ljharb/side-channel",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/side-channel/LICENSE"
+  },
+  "signal-exit@3.0.7": {
+    "licenses": "ISC",
+    "repository": "https://github.com/tapjs/signal-exit",
+    "publisher": "Ben Coe",
+    "email": "ben@npmjs.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/signal-exit",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/signal-exit/LICENSE.txt"
+  },
+  "simple-update-notifier@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/alexbrazier/simple-update-notifier",
+    "publisher": "alexbrazier",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/simple-update-notifier",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/simple-update-notifier/LICENSE"
+  },
+  "sisteransi@1.0.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/terkelg/sisteransi",
+    "publisher": "Terkel Gjervig",
+    "email": "terkel@terkel.com",
+    "url": "https://terkel.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sisteransi",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sisteransi/license"
+  },
+  "slash@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/slash",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/slash",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/slash/license"
+  },
+  "slide@1.1.6": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/slide-flow-control",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/slide",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/slide/LICENSE"
+  },
+  "sort-keys-length@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kevva/sort-keys-length",
+    "publisher": "Kevin Mårtensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "https://github.com/kevva",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sort-keys-length",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sort-keys-length/LICENSE.md"
+  },
+  "sort-keys@1.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/sort-keys",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sort-keys",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sort-keys/license"
+  },
+  "source-map-support@0.5.21": {
+    "licenses": "MIT",
+    "repository": "https://github.com/evanw/node-source-map-support",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/source-map-support",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/source-map-support/LICENSE.md"
+  },
+  "source-map@0.7.4": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/mozilla/source-map",
+    "publisher": "Nick Fitzgerald",
+    "email": "nfitzgerald@mozilla.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/source-map",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/source-map/LICENSE"
+  },
+  "spdx-compare@1.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kemitchell/spdx-compare.js",
+    "publisher": "Kyle E. Mitchell",
+    "email": "kyle@kemitchell.com",
+    "url": "https://kemitchell.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-compare",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-compare/LICENSE.md"
+  },
+  "spdx-correct@3.2.0": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/jslicense/spdx-correct.js",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-correct",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-correct/LICENSE"
+  },
+  "spdx-exceptions@2.5.0": {
+    "licenses": "CC-BY-3.0",
+    "repository": "https://github.com/kemitchell/spdx-exceptions.json",
+    "publisher": "The Linux Foundation",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-exceptions",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-exceptions/README.md"
+  },
+  "spdx-expression-parse@3.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jslicense/spdx-expression-parse.js",
+    "publisher": "Kyle E. Mitchell",
+    "email": "kyle@kemitchell.com",
+    "url": "https://kemitchell.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-expression-parse",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-expression-parse/LICENSE"
+  },
+  "spdx-license-ids@3.0.21": {
+    "licenses": "CC0-1.0",
+    "repository": "https://github.com/jslicense/spdx-license-ids",
+    "publisher": "Shinnosuke Watanabe",
+    "url": "https://github.com/shinnn",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-license-ids",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-license-ids/README.md"
+  },
+  "spdx-ranges@2.1.1": {
+    "licenses": "(MIT AND CC-BY-3.0)",
+    "repository": "https://github.com/kemitchell/spdx-ranges.js",
+    "publisher": "The Linux Foundation",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-ranges",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-ranges/LICENSE.md"
+  },
+  "spdx-satisfies@4.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kemitchell/spdx-satisfies.js",
+    "publisher": "Kyle E. Mitchell",
+    "email": "kyle@kemitchell.com",
+    "url": "https://kemitchell.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-satisfies",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/spdx-satisfies/LICENSE"
+  },
+  "sprintf-js@1.0.3": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/alexei/sprintf.js",
+    "publisher": "Alexandru Marasteanu",
+    "email": "hello@alexei.ro",
+    "url": "http://alexei.ro/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sprintf-js",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/sprintf-js/LICENSE"
+  },
+  "stack-utils@2.0.6": {
+    "licenses": "MIT",
+    "repository": "https://github.com/tapjs/stack-utils",
+    "publisher": "James Talmage",
+    "email": "james@talmage.io",
+    "url": "github.com/jamestalmage",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/stack-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/stack-utils/LICENSE.md"
+  },
+  "statuses@2.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/statuses",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/statuses",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/statuses/LICENSE"
+  },
+  "streamsearch@1.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mscdex/streamsearch",
+    "publisher": "Brian White",
+    "email": "mscdex@mscdex.net",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/streamsearch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/streamsearch/LICENSE"
+  },
+  "streamx@2.22.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mafintosh/streamx",
+    "publisher": "Mathias Buus",
+    "url": "@mafintosh",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/streamx",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/streamx/LICENSE"
+  },
+  "string-length@4.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/string-length",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/string-length",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/string-length/license"
+  },
+  "string-width@4.2.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/string-width",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/string-width",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/string-width/license"
+  },
+  "strip-ansi@6.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chalk/strip-ansi",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-ansi",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-ansi/license"
+  },
+  "strip-bom@4.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/strip-bom",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-bom",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-bom/license"
+  },
+  "strip-dirs@3.0.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/shinnn/node-strip-dirs",
+    "publisher": "Shinnosuke Watanabe",
+    "url": "https://github.com/shinnn",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-dirs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-dirs/LICENSE"
+  },
+  "strip-final-newline@2.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/strip-final-newline",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-final-newline",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-final-newline/license"
+  },
+  "strip-json-comments@3.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/strip-json-comments",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-json-comments",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strip-json-comments/license"
+  },
+  "strtok3@9.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Borewit/strtok3",
+    "publisher": "Borewit",
+    "url": "https://github.com/Borewit",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strtok3",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/strtok3/LICENSE"
+  },
+  "superagent@9.0.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ladjs/superagent",
+    "publisher": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/superagent",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/superagent/LICENSE"
+  },
+  "supertest@7.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/ladjs/supertest",
+    "publisher": "TJ Holowaychuk",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supertest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supertest/LICENSE"
+  },
+  "supports-color@5.5.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chalk/supports-color",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supports-color",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supports-color/license"
+  },
+  "supports-preserve-symlinks-flag@1.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/inspect-js/node-supports-preserve-symlinks-flag",
+    "publisher": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supports-preserve-symlinks-flag",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/supports-preserve-symlinks-flag/LICENSE"
+  },
+  "tar-stream@3.1.7": {
+    "licenses": "MIT",
+    "repository": "https://github.com/mafintosh/tar-stream",
+    "publisher": "Mathias Buus",
+    "email": "mathiasbuus@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/tar-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/tar-stream/LICENSE"
+  },
+  "test-exclude@6.0.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/istanbuljs/test-exclude",
+    "publisher": "Ben Coe",
+    "email": "ben@npmjs.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/test-exclude",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/test-exclude/LICENSE.txt"
+  },
+  "text-decoder@1.2.3": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/holepunchto/text-decoder",
+    "publisher": "Holepunch",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/text-decoder",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/text-decoder/LICENSE"
+  },
+  "through@2.3.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/dominictarr/through",
+    "publisher": "Dominic Tarr",
+    "email": "dominic.tarr@gmail.com",
+    "url": "dominictarr.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/through",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/through/LICENSE.APACHE2"
+  },
+  "tmpl@1.0.5": {
+    "licenses": "BSD-3-Clause",
+    "repository": "https://github.com/daaku/nodejs-tmpl",
+    "publisher": "Naitik Shah",
+    "email": "n@daaku.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/tmpl",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/tmpl/license"
+  },
+  "to-regex-range@5.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/micromatch/to-regex-range",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/to-regex-range",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/to-regex-range/LICENSE"
+  },
+  "toidentifier@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/component/toidentifier",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/toidentifier",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/toidentifier/LICENSE"
+  },
+  "token-types@6.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/Borewit/token-types",
+    "publisher": "Borewit",
+    "url": "https://github.com/Borewit",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/token-types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/token-types/LICENSE"
+  },
+  "touch@3.1.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/node-touch",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/touch",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/touch/LICENSE"
+  },
+  "treeify@1.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/notatestuser/treeify",
+    "publisher": "Luke Plaster",
+    "email": "notatestuser@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/treeify",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/treeify/LICENSE"
+  },
+  "ts-api-utils@2.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/JoshuaKGoldberg/ts-api-utils",
+    "publisher": "JoshuaKGoldberg",
+    "email": "npm@joshuakgoldberg.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-api-utils",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-api-utils/LICENSE.md"
+  },
+  "ts-jest@29.2.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kulshekhar/ts-jest",
+    "publisher": "Kulshekhar Kabra",
+    "email": "kulshekhar@users.noreply.github.com",
+    "url": "https://github.com/kulshekhar",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-jest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-jest/LICENSE.md"
+  },
+  "ts-node@10.9.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/TypeStrong/ts-node",
+    "publisher": "Blake Embrey",
+    "email": "hello@blakeembrey.com",
+    "url": "http://blakeembrey.me",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-node",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/ts-node/LICENSE"
+  },
+  "tslib@2.8.1": {
+    "licenses": "0BSD",
+    "repository": "https://github.com/Microsoft/tslib",
+    "publisher": "Microsoft Corp.",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/tslib",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/tslib/LICENSE.txt"
+  },
+  "type-check@0.4.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/gkz/type-check",
+    "publisher": "George Zahariev",
+    "email": "z@georgezahariev.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-check",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-check/LICENSE"
+  },
+  "type-detect@4.0.8": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chaijs/type-detect",
+    "publisher": "Jake Luer",
+    "email": "jake@alogicalparadox.com",
+    "url": "http://alogicalparadox.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-detect",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-detect/LICENSE"
+  },
+  "type-fest@0.21.3": {
+    "licenses": "(MIT OR CC0-1.0)",
+    "repository": "https://github.com/sindresorhus/type-fest",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-fest",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-fest/license"
+  },
+  "type-is@1.6.18": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/type-is",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-is",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/type-is/LICENSE"
+  },
+  "typescript-eslint@8.23.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/typescript-eslint/typescript-eslint",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript-eslint",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript-eslint/LICENSE"
+  },
+  "typescript@5.7.3": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/microsoft/TypeScript",
+    "publisher": "Microsoft Corp.",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/typescript/LICENSE.txt"
+  },
+  "uint8array-extras@1.4.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/uint8array-extras",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/uint8array-extras",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/uint8array-extras/license"
+  },
+  "unbzip2-stream@1.4.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/regular/unbzip2-stream",
+    "publisher": "Jan Bölsche",
+    "email": "jan@lagomorph.de",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/unbzip2-stream",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/unbzip2-stream/LICENSE"
+  },
+  "undefsafe@2.0.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/remy/undefsafe",
+    "publisher": "Remy Sharp",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/undefsafe",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/undefsafe/LICENSE"
+  },
+  "undici-types@6.20.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/nodejs/undici",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/undici-types",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/undici-types/LICENSE"
+  },
+  "unpipe@1.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/stream-utils/unpipe",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/unpipe",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/unpipe/LICENSE"
+  },
+  "update-browserslist-db@1.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/browserslist/update-db",
+    "publisher": "Andrey Sitnik",
+    "email": "andrey@sitnik.ru",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/update-browserslist-db",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/update-browserslist-db/LICENSE"
+  },
+  "uri-js@4.4.1": {
+    "licenses": "BSD-2-Clause",
+    "repository": "https://github.com/garycourt/uri-js",
+    "publisher": "Gary Court",
+    "email": "gary.court@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/uri-js",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/uri-js/LICENSE"
+  },
+  "urlpattern-polyfill@10.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kenchris/urlpattern-polyfill",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/urlpattern-polyfill",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/urlpattern-polyfill/LICENSE"
+  },
+  "util-extend@1.0.3": {
+    "licenses": "MIT",
+    "repository": "https://github.com/isaacs/util-extend",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/util-extend",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/util-extend/LICENSE"
+  },
+  "utils-merge@1.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jaredhanson/utils-merge",
+    "publisher": "Jared Hanson",
+    "email": "jaredhanson@gmail.com",
+    "url": "http://www.jaredhanson.net/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/utils-merge",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/utils-merge/LICENSE"
+  },
+  "v8-compile-cache-lib@3.0.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/cspotcode/v8-compile-cache-lib",
+    "publisher": "Andrew Bradley",
+    "email": "cspotcode@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/v8-compile-cache-lib",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/v8-compile-cache-lib/LICENSE"
+  },
+  "v8-to-istanbul@9.3.0": {
+    "licenses": "ISC",
+    "repository": "https://github.com/istanbuljs/v8-to-istanbul",
+    "publisher": "Ben Coe",
+    "email": "ben@npmjs.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/v8-to-istanbul",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/v8-to-istanbul/LICENSE.txt"
+  },
+  "validate-npm-package-license@3.0.4": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/kemitchell/validate-npm-package-license.js",
+    "publisher": "Kyle E. Mitchell",
+    "email": "kyle@kemitchell.com",
+    "url": "https://kemitchell.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/validate-npm-package-license",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/validate-npm-package-license/LICENSE"
+  },
+  "value-or-promise@1.0.12": {
+    "licenses": "MIT",
+    "repository": "https://github.com/yaacovCR/value-or-promise",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/value-or-promise",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/value-or-promise/LICENSE"
+  },
+  "vary@1.1.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jshttp/vary",
+    "publisher": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/vary",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/vary/LICENSE"
+  },
+  "walker@1.0.8": {
+    "licenses": "Apache-2.0",
+    "repository": "https://github.com/daaku/nodejs-walker",
+    "publisher": "Naitik Shah",
+    "email": "n@daaku.org",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/walker",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/walker/LICENSE"
+  },
+  "which@2.0.2": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/node-which",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/which",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/which/LICENSE"
+  },
+  "word-wrap@1.2.5": {
+    "licenses": "MIT",
+    "repository": "https://github.com/jonschlinkert/word-wrap",
+    "publisher": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/word-wrap",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/word-wrap/LICENSE"
+  },
+  "wrap-ansi@7.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/chalk/wrap-ansi",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/wrap-ansi",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/wrap-ansi/license"
+  },
+  "wrappy@1.0.2": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/wrappy",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/wrappy",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/wrappy/LICENSE"
+  },
+  "write-file-atomic@4.0.2": {
+    "licenses": "ISC",
+    "repository": "https://github.com/npm/write-file-atomic",
+    "publisher": "GitHub Inc.",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/write-file-atomic",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/write-file-atomic/LICENSE.md"
+  },
+  "y18n@5.0.8": {
+    "licenses": "ISC",
+    "repository": "https://github.com/yargs/y18n",
+    "publisher": "Ben Coe",
+    "email": "bencoe@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/y18n",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/y18n/LICENSE"
+  },
+  "yallist@3.1.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/isaacs/yallist",
+    "publisher": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yallist",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yallist/LICENSE"
+  },
+  "yargs-parser@21.1.1": {
+    "licenses": "ISC",
+    "repository": "https://github.com/yargs/yargs-parser",
+    "publisher": "Ben Coe",
+    "email": "ben@npmjs.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yargs-parser",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yargs-parser/LICENSE.txt"
+  },
+  "yargs@17.7.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/yargs/yargs",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yargs",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yargs/LICENSE"
+  },
+  "yauzl@3.2.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/thejoshwolfe/yauzl",
+    "publisher": "Josh Wolfe",
+    "email": "thejoshwolfe@gmail.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yauzl",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yauzl/LICENSE"
+  },
+  "yn@3.1.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/yn",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yn",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yn/license"
+  },
+  "yocto-queue@0.1.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/sindresorhus/yocto-queue",
+    "publisher": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com",
+    "path": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yocto-queue",
+    "licenseFile": "/home/runner/work/node-graphql-code-test/node-graphql-code-test/node_modules/yocto-queue/license"
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^9.19.0",
     "globals": "^15.14.0",
     "jest": "^29.7.0",
+    "license-checker": "^25.0.1",
     "nodemon": "^3.1.9",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.13.1)(ts-node@10.9.2(@swc/core@1.10.14)(@types/node@22.13.1)(typescript@5.7.3))
+      license-checker:
+        specifier: ^25.0.1
+        version: 25.0.1
       nodemon:
         specifier: ^3.1.9
         version: 3.1.9
@@ -991,6 +994,9 @@ packages:
     resolution: {integrity: sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==}
     engines: {node: ^14.14.0 || >=16.0.0}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1020,6 +1026,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1043,6 +1053,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-find-index@1.0.2:
+    resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
+    engines: {node: '>=0.10.0'}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -1183,6 +1197,10 @@ packages:
   caniuse-lite@1.0.30001697:
     resolution: {integrity: sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==}
 
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1213,9 +1231,15 @@ packages:
   collect-v8-coverage@1.0.2:
     resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
 
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -1286,6 +1310,14 @@ packages:
       supports-color:
         optional: true
 
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
@@ -1294,6 +1326,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  debuglog@1.0.1:
+    resolution: {integrity: sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1408,6 +1444,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -1704,6 +1744,9 @@ packages:
   hexoid@2.0.0:
     resolution: {integrity: sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==}
     engines: {node: '>=8'}
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2020,6 +2063,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  license-checker@25.0.1:
+    resolution: {integrity: sha512-mET5AIwl7MR2IAKYYoVBBpV0OnkKQ1xGj2IMMeEFIs42QAkEVjRtFZGWmQ28WeU7MP779iAgOaOy93Mn44mn6g==}
+    hasBin: true
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2128,6 +2175,13 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
   morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
     engines: {node: '>= 0.8.0'}
@@ -2156,6 +2210,13 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  nopt@4.0.3:
+    resolution: {integrity: sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==}
+    hasBin: true
+
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -2163,6 +2224,9 @@ packages:
   normalize-url@8.0.1:
     resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
     engines: {node: '>=14.16'}
+
+  npm-normalize-package-bin@1.0.1:
+    resolution: {integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -2194,6 +2258,18 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-homedir@1.0.2:
+    resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
+    engines: {node: '>=0.10.0'}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+
+  osenv@0.1.5:
+    resolution: {integrity: sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==}
+    deprecated: This package is no longer supported.
 
   oxc-resolver@1.12.0:
     resolution: {integrity: sha512-YlaCIArvWNKCWZFRrMjhh2l5jK80eXnpYP+bhRc1J/7cW3TiyEY0ngJo73o/5n8hA3+4yLdTmXLNTQ3Ncz50LQ==}
@@ -2329,6 +2405,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  read-installed@4.0.3:
+    resolution: {integrity: sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==}
+    deprecated: This package is no longer supported.
+
+  read-package-json@2.1.2:
+    resolution: {integrity: sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==}
+    deprecated: This package is no longer supported. Please use @npmcli/package-json instead.
+
+  readdir-scoped-modules@1.1.0:
+    resolution: {integrity: sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==}
+    deprecated: This functionality has been moved to @npmcli/fs
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -2393,6 +2481,10 @@ packages:
     resolution: {integrity: sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==}
     engines: {node: '>=12'}
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2456,6 +2548,9 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slide@1.1.6:
+    resolution: {integrity: sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==}
+
   sort-keys-length@1.0.1:
     resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
     engines: {node: '>=0.10.0'}
@@ -2477,6 +2572,27 @@ packages:
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
+
+  spdx-compare@1.0.0:
+    resolution: {integrity: sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.21:
+    resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
+
+  spdx-ranges@2.1.1:
+    resolution: {integrity: sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==}
+
+  spdx-satisfies@4.0.1:
+    resolution: {integrity: sha512-WVzZ/cXAzoNmjCWiEluEA3BjHp5tiUmmhn9MK+X0tBbR9sOqtC6UQwmgCNrAIZvNlMuBUYAaHYfb2oqlF9SwKA==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -2583,6 +2699,10 @@ packages:
     resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
     hasBin: true
 
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
+
   ts-api-utils@2.0.1:
     resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
     engines: {node: '>=18.12'}
@@ -2687,6 +2807,9 @@ packages:
   urlpattern-polyfill@10.0.0:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
 
+  util-extend@1.0.3:
+    resolution: {integrity: sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -2697,6 +2820,9 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   value-or-promise@1.0.12:
     resolution: {integrity: sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==}
@@ -3827,6 +3953,8 @@ snapshots:
     dependencies:
       arch: 3.0.0
 
+  abbrev@1.1.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -3856,6 +3984,10 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -3877,6 +4009,8 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  array-find-index@1.0.2: {}
 
   array-flatten@1.1.1: {}
 
@@ -4057,6 +4191,12 @@ snapshots:
 
   caniuse-lite@1.0.30001697: {}
 
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4090,9 +4230,15 @@ snapshots:
 
   collect-v8-coverage@1.0.2: {}
 
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
+
+  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -4156,11 +4302,17 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
+
+  debuglog@1.0.1: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -4235,6 +4387,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -4599,6 +4753,8 @@ snapshots:
   helmet@8.0.0: {}
 
   hexoid@2.0.0: {}
+
+  hosted-git-info@2.8.9: {}
 
   html-escaper@2.0.2: {}
 
@@ -5079,6 +5235,21 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  license-checker@25.0.1:
+    dependencies:
+      chalk: 2.4.2
+      debug: 3.2.7
+      mkdirp: 0.5.6
+      nopt: 4.0.3
+      read-installed: 4.0.3
+      semver: 5.7.2
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+      spdx-satisfies: 4.0.1
+      treeify: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   lines-and-columns@1.2.4: {}
 
   locate-path@5.0.0:
@@ -5158,6 +5329,12 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimist@1.2.8: {}
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
   morgan@1.10.0:
     dependencies:
       basic-auth: 2.0.1
@@ -5193,9 +5370,23 @@ snapshots:
       touch: 3.1.1
       undefsafe: 2.0.5
 
+  nopt@4.0.3:
+    dependencies:
+      abbrev: 1.1.1
+      osenv: 0.1.5
+
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.10
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
   normalize-path@3.0.0: {}
 
   normalize-url@8.0.1: {}
+
+  npm-normalize-package-bin@1.0.1: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -5229,6 +5420,15 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  os-homedir@1.0.2: {}
+
+  os-tmpdir@1.0.2: {}
+
+  osenv@0.1.5:
+    dependencies:
+      os-homedir: 1.0.2
+      os-tmpdir: 1.0.2
 
   oxc-resolver@1.12.0:
     optionalDependencies:
@@ -5352,6 +5552,31 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  read-installed@4.0.3:
+    dependencies:
+      debuglog: 1.0.1
+      read-package-json: 2.1.2
+      readdir-scoped-modules: 1.1.0
+      semver: 5.7.2
+      slide: 1.1.6
+      util-extend: 1.0.3
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  read-package-json@2.1.2:
+    dependencies:
+      glob: 7.2.3
+      json-parse-even-better-errors: 2.3.1
+      normalize-package-data: 2.5.0
+      npm-normalize-package-bin: 1.0.1
+
+  readdir-scoped-modules@1.1.0:
+    dependencies:
+      debuglog: 1.0.1
+      dezalgo: 1.0.4
+      graceful-fs: 4.2.11
+      once: 1.4.0
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -5401,6 +5626,8 @@ snapshots:
   semver-truncate@3.0.0:
     dependencies:
       semver: 7.6.3
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -5481,6 +5708,8 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slide@1.1.6: {}
+
   sort-keys-length@1.0.1:
     dependencies:
       sort-keys: 1.1.2
@@ -5502,6 +5731,34 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
+
+  spdx-compare@1.0.0:
+    dependencies:
+      array-find-index: 1.0.2
+      spdx-expression-parse: 3.0.1
+      spdx-ranges: 2.1.1
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.21
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.21
+
+  spdx-license-ids@3.0.21: {}
+
+  spdx-ranges@2.1.1: {}
+
+  spdx-satisfies@4.0.1:
+    dependencies:
+      spdx-compare: 1.0.0
+      spdx-expression-parse: 3.0.1
+      spdx-ranges: 2.1.1
 
   sprintf-js@1.0.3: {}
 
@@ -5619,6 +5876,8 @@ snapshots:
 
   touch@3.1.1: {}
 
+  treeify@1.1.0: {}
+
   ts-api-utils@2.0.1(typescript@5.7.3):
     dependencies:
       typescript: 5.7.3
@@ -5715,6 +5974,8 @@ snapshots:
 
   urlpattern-polyfill@10.0.0: {}
 
+  util-extend@1.0.3: {}
+
   utils-merge@1.0.1: {}
 
   v8-compile-cache-lib@3.0.1:
@@ -5725,6 +5986,11 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
 
   value-or-promise@1.0.12: {}
 


### PR DESCRIPTION
Implements the same `update-licenses` workflow from: https://github.com/mattfsourcecode/fastify-swc-typescript-server/blob/master/.github/workflows/update-licenses.yml, with Personal Access Token (PAT) settings in the repository configured to access the necessary secrets.

The only change to the workflow is the addition os the `--ignore-scripts` flag in the `pnpm install` command, which prevents an error that does not need to be resolved, since the custom `pre-commit` hook is not currently needed in the GitHub Actions environment.

Closes #94